### PR TITLE
JPA를 활용한 Entity 저장 및 조회 테스트 API

### DIFF
--- a/src/main/java/com/renzzle/backend/domain/test/api/TestController.java
+++ b/src/main/java/com/renzzle/backend/domain/test/api/TestController.java
@@ -1,13 +1,20 @@
 package com.renzzle.backend.domain.test.api;
 
+import com.renzzle.backend.domain.test.api.request.SaveEntityRequest;
 import com.renzzle.backend.domain.test.api.response.HelloResponse;
+import com.renzzle.backend.domain.test.api.response.SaveEntityResponse;
+import com.renzzle.backend.domain.test.domain.TestEntity;
 import com.renzzle.backend.domain.test.service.TestService;
 import com.renzzle.backend.global.common.ApiResponse;
 import com.renzzle.backend.global.util.ApiUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.ValidationException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+import static com.renzzle.backend.global.util.BindingResultUtils.getErrorMessages;
 
 @RestController
 @RequestMapping("/api/test")
@@ -21,6 +28,29 @@ public class TestController {
     @GetMapping("/hello/{name}")
     public ApiResponse<HelloResponse> helloToServer(@PathVariable("name") String name) {
         return ApiUtils.success(testService.getHelloResponse(name));
+    }
+
+    @Operation(summary = "Server DB test", description = "Test saving entity on DB through JPA")
+    @PostMapping("/save/jpa")
+    public ApiResponse<SaveEntityResponse> saveTestEntity(@Valid @RequestBody SaveEntityRequest request, BindingResult bindingResult) {
+        if(bindingResult.hasErrors()) {
+            throw new ValidationException(getErrorMessages(bindingResult));
+        }
+
+        TestEntity entity = TestEntity
+                .builder()
+                .name(request.name())
+                .build();
+
+        TestEntity result = testService.saveEntity(entity);
+
+        SaveEntityResponse response = SaveEntityResponse
+                .builder()
+                .id(result.getId())
+                .name(result.getName())
+                .build();
+
+        return ApiUtils.success(response);
     }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/test/api/TestController.java
+++ b/src/main/java/com/renzzle/backend/domain/test/api/TestController.java
@@ -1,6 +1,7 @@
 package com.renzzle.backend.domain.test.api;
 
 import com.renzzle.backend.domain.test.api.request.SaveEntityRequest;
+import com.renzzle.backend.domain.test.api.response.FindEntityResponse;
 import com.renzzle.backend.domain.test.api.response.HelloResponse;
 import com.renzzle.backend.domain.test.api.response.SaveEntityResponse;
 import com.renzzle.backend.domain.test.domain.TestEntity;
@@ -45,6 +46,20 @@ public class TestController {
         TestEntity result = testService.saveEntity(entity);
 
         SaveEntityResponse response = SaveEntityResponse
+                .builder()
+                .id(result.getId())
+                .name(result.getName())
+                .build();
+
+        return ApiUtils.success(response);
+    }
+
+    @Operation(summary = "Server DB test", description = "Test finding entity on DB through JPA")
+    @GetMapping("/find/jpa/{Id}")
+    public ApiResponse<FindEntityResponse> findTestEntity(@PathVariable("Id") Long id) {
+        TestEntity result = testService.findEntityById(id);
+
+        FindEntityResponse response = FindEntityResponse
                 .builder()
                 .id(result.getId())
                 .name(result.getName())

--- a/src/main/java/com/renzzle/backend/domain/test/api/request/SaveEntityRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/test/api/request/SaveEntityRequest.java
@@ -1,0 +1,8 @@
+package com.renzzle.backend.domain.test.api.request;
+
+import jakarta.validation.constraints.Size;
+
+public record SaveEntityRequest(
+        @Size(max = 6, message = "이름은 6자 이하만 가능합니다")
+        String name
+) { }

--- a/src/main/java/com/renzzle/backend/domain/test/api/response/FindEntityResponse.java
+++ b/src/main/java/com/renzzle/backend/domain/test/api/response/FindEntityResponse.java
@@ -1,0 +1,7 @@
+package com.renzzle.backend.domain.test.api.response;
+
+import lombok.Builder;
+
+@Builder
+public record FindEntityResponse(Long id, String name) {
+}

--- a/src/main/java/com/renzzle/backend/domain/test/api/response/SaveEntityResponse.java
+++ b/src/main/java/com/renzzle/backend/domain/test/api/response/SaveEntityResponse.java
@@ -3,5 +3,5 @@ package com.renzzle.backend.domain.test.api.response;
 import lombok.Builder;
 
 @Builder
-public record HelloResponse(String message) {
+public record SaveEntityResponse(Long id, String name) {
 }

--- a/src/main/java/com/renzzle/backend/domain/test/dao/TestRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/test/dao/TestRepository.java
@@ -1,0 +1,9 @@
+package com.renzzle.backend.domain.test.dao;
+
+import com.renzzle.backend.domain.test.domain.TestEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TestRepository extends JpaRepository<TestEntity, Long> {
+}

--- a/src/main/java/com/renzzle/backend/domain/test/domain/TestEntity.java
+++ b/src/main/java/com/renzzle/backend/domain/test/domain/TestEntity.java
@@ -1,0 +1,23 @@
+package com.renzzle.backend.domain.test.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+@Builder
+public class TestEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+
+}

--- a/src/main/java/com/renzzle/backend/domain/test/service/TestService.java
+++ b/src/main/java/com/renzzle/backend/domain/test/service/TestService.java
@@ -1,13 +1,24 @@
 package com.renzzle.backend.domain.test.service;
 
+import com.renzzle.backend.domain.test.api.request.SaveEntityRequest;
 import com.renzzle.backend.domain.test.api.response.HelloResponse;
+import com.renzzle.backend.domain.test.dao.TestRepository;
+import com.renzzle.backend.domain.test.domain.TestEntity;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class TestService {
+
+    private final TestRepository testRepository;
 
     public HelloResponse getHelloResponse(String name) {
         return new HelloResponse("Hello " + name + "!");
+    }
+
+    public TestEntity saveEntity(TestEntity entity) {
+        return testRepository.save(entity);
     }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/test/service/TestService.java
+++ b/src/main/java/com/renzzle/backend/domain/test/service/TestService.java
@@ -4,8 +4,12 @@ import com.renzzle.backend.domain.test.api.request.SaveEntityRequest;
 import com.renzzle.backend.domain.test.api.response.HelloResponse;
 import com.renzzle.backend.domain.test.dao.TestRepository;
 import com.renzzle.backend.domain.test.domain.TestEntity;
+import com.renzzle.backend.global.exception.CustomException;
+import com.renzzle.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +23,13 @@ public class TestService {
 
     public TestEntity saveEntity(TestEntity entity) {
         return testRepository.save(entity);
+    }
+
+    public TestEntity findEntityById(Long id) {
+        Optional<TestEntity> result = testRepository.findById(id);
+        if(result.isEmpty())
+            throw new CustomException(ErrorCode.GLOBAL_NOT_FOUND);
+        return result.orElse(null);
     }
 
 }

--- a/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"G500","서버 내부에서 에러가 발생하였습니다");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"G500","서버 내부에서 에러가 발생하였습니다"),
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "G400", "올바르지 않은 요청입니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"G500","서버 내부에서 에러가 발생하였습니다"),
-    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "G400", "올바르지 않은 요청입니다");
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "G400", "올바르지 않은 요청입니다"),
+    GLOBAL_NOT_FOUND(HttpStatus.NOT_FOUND, "G404", "결과를 찾을 수 없습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/renzzle/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/renzzle/backend/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.renzzle.backend.global.exception;
 
 import com.renzzle.backend.global.util.ApiUtils;
+import jakarta.validation.ValidationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -13,6 +14,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(RuntimeException.class)
     private ResponseEntity<?> handleException(RuntimeException e) {
         return handleException(e, ErrorCode.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+    }
+
+    @ExceptionHandler(ValidationException.class)
+    private ResponseEntity<?> handleValidationException(ValidationException e) {
+        return handleException(e, ErrorCode.VALIDATION_ERROR, e.getMessage());
     }
 
     @ExceptionHandler(CustomException.class)

--- a/src/main/java/com/renzzle/backend/global/util/BindingResultUtils.java
+++ b/src/main/java/com/renzzle/backend/global/util/BindingResultUtils.java
@@ -1,0 +1,14 @@
+package com.renzzle.backend.global.util;
+
+import org.springframework.validation.BindingResult;
+
+public class BindingResultUtils {
+
+    public static String getErrorMessages(BindingResult bindingResult) {
+        StringBuilder errorMessages = new StringBuilder();
+        bindingResult.getAllErrors()
+                .forEach(error -> errorMessages.append(error.getDefaultMessage()).append(". "));
+        return errorMessages.toString();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,8 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
     open-in-view: true
     show-sql: true
+    hibernate:
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
### ✏️ 작업 개요
JPA를 활용한 Entity 저장 및 조회 테스트 API

### 🔨 작업 상세 내용
1. JPA를 활용해 Test Entity 저장 API 구현
2. JPA를 활용해 Test Entity 조회 API 구현
3. BindingResultUtils 클래스 추가 (Validation을 위해)
4. Validation Error 및 Not Found Error 에러 코드 추가 및 핸들러 추가
