### PR TITLE
유저 관련 Auth API 작업 (인증/인가X)

### DIFF
--- a/src/main/java/com/renzzle/backend/domain/auth/api/AuthController.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/AuthController.java
@@ -67,7 +67,7 @@ public class AuthController {
         }
 
         boolean isCorrect = emailService.confirmCode(request.email(), request.code());
-        if(!isCorrect) throw new CustomException(ErrorCode.NOT_VALID_CODE);
+        if(!isCorrect) throw new CustomException(ErrorCode.INVALID_EMAIL_AUTH_CODE);
 
         String authVerityToken = accountService.createAuthVerityToken(request.email());
 

--- a/src/main/java/com/renzzle/backend/domain/auth/api/AuthController.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/AuthController.java
@@ -2,6 +2,7 @@ package com.renzzle.backend.domain.auth.api;
 
 import com.renzzle.backend.domain.auth.api.request.AuthEmailRequest;
 import com.renzzle.backend.domain.auth.api.request.ConfirmCodeRequest;
+import com.renzzle.backend.domain.auth.api.request.LoginRequest;
 import com.renzzle.backend.domain.auth.api.request.SignupRequest;
 import com.renzzle.backend.domain.auth.api.response.AuthEmailResponse;
 import com.renzzle.backend.domain.auth.api.response.ConfirmCodeResponse;
@@ -26,7 +27,7 @@ import static com.renzzle.backend.global.util.BindingResultUtils.getErrorMessage
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-@Tag(name = "Auth API", description = "Auth & account api")
+@Tag(name = "Auth API", description = "Auth & Account API")
 public class AuthController {
 
     private final EmailService emailService;
@@ -58,7 +59,7 @@ public class AuthController {
                 .build());
     }
 
-    @Operation(summary = "Confirm code", description = "Authenticate code & return token for sign up")
+    @Operation(summary = "Confirm code", description = "Authenticate code & Return token for sign up")
     @PostMapping("/confirmCode")
     public ApiResponse<ConfirmCodeResponse> confirmCode(@Valid @RequestBody ConfirmCodeRequest request, BindingResult bindingResult) {
         if(bindingResult.hasErrors()) {
@@ -84,7 +85,7 @@ public class AuthController {
         return ApiUtils.success(accountService.isDuplicateNickname(nickname));
     }
 
-    @Operation(summary = "Create new account", description = "Issue authentication tokens for server access")
+    @Operation(summary = "Create new account", description = "Create new account & Issue authentication tokens for server access")
     @PostMapping("/signup")
     public ApiResponse<LoginResponse> signup(@Valid @RequestBody SignupRequest request, BindingResult bindingResult) {
         if(bindingResult.hasErrors()) {
@@ -96,6 +97,18 @@ public class AuthController {
         }
 
         Long userId = accountService.createNewUser(request.email(), request.password(), request.nickname());
+
+        return ApiUtils.success(accountService.createAuthTokens(userId));
+    }
+
+    @Operation(summary = "Login to service", description = "Issue authentication tokens for server access")
+    @PostMapping("/login")
+    public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request, BindingResult bindingResult) {
+        if(bindingResult.hasErrors()) {
+            throw new ValidationException(getErrorMessages(bindingResult));
+        }
+
+        long userId = accountService.verifyLoginInfo(request.email(), request.password());
 
         return ApiUtils.success(accountService.createAuthTokens(userId));
     }

--- a/src/main/java/com/renzzle/backend/domain/auth/api/AuthController.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/AuthController.java
@@ -6,7 +6,7 @@ import com.renzzle.backend.domain.auth.api.response.AuthEmailResponse;
 import com.renzzle.backend.domain.auth.api.response.ConfirmCodeResponse;
 import com.renzzle.backend.domain.auth.service.AccountService;
 import com.renzzle.backend.domain.auth.service.EmailService;
-import com.renzzle.backend.global.common.ApiResponse;
+import com.renzzle.backend.global.common.response.ApiResponse;
 import com.renzzle.backend.global.exception.CustomException;
 import com.renzzle.backend.global.exception.ErrorCode;
 import com.renzzle.backend.global.util.ApiUtils;

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/LoginRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.renzzle.backend.domain.auth.api.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+
+public record LoginRequest(
+        @Email(message = "이메일 형식이 아닙니다")
+        String email,
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
+        String password
+) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/SignupRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/SignupRequest.java
@@ -1,0 +1,15 @@
+package com.renzzle.backend.domain.auth.api.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record SignupRequest(
+        @Email(message = "이메일 형식이 아닙니다")
+        String email,
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
+        String password,
+        @Size(min = 2, max = 8, message = "닉네임은 2글자 이상, 최대 8글자까지 가능합니다")
+        String nickname,
+        String authVerityToken
+) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/api/response/LoginResponse.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/response/LoginResponse.java
@@ -1,0 +1,14 @@
+package com.renzzle.backend.domain.auth.api.response;
+
+import lombok.Builder;
+
+import java.time.Instant;
+
+@Builder
+public record LoginResponse(
+        String grantType,
+        String accessToken,
+        String refreshToken,
+        Instant accessTokenExpiredAt,
+        Instant refreshTokenExpiredAt
+) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/dao/RefreshTokenRedisRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/dao/RefreshTokenRedisRepository.java
@@ -1,0 +1,7 @@
+package com.renzzle.backend.domain.auth.dao;
+
+import com.renzzle.backend.domain.auth.domain.RefreshTokenEntity;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRedisRepository extends CrudRepository<RefreshTokenEntity, Long> {
+}

--- a/src/main/java/com/renzzle/backend/domain/auth/domain/RefreshTokenEntity.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/domain/RefreshTokenEntity.java
@@ -1,0 +1,14 @@
+package com.renzzle.backend.domain.auth.domain;
+
+import lombok.Builder;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import static com.renzzle.backend.domain.auth.service.JwtProvider.REFRESH_TOKEN_VALID_MINUTE;
+
+@Builder
+@RedisHash(value = "refreshToken", timeToLive = 60 * REFRESH_TOKEN_VALID_MINUTE)
+public record RefreshTokenEntity(
+        @Id
+        Long id,
+        String token
+) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
@@ -52,6 +52,10 @@ public class AccountService {
         if(isDuplicatedEmail(email))
             throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
 
+        // validate nickname
+        if(isDuplicateNickname(nickname))
+            throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
+
         String encodedPassword = passwordEncoder.encode(password);
 
         UserEntity user = UserEntity.builder()

--- a/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
-
 import static com.renzzle.backend.domain.auth.service.JwtProvider.ACCESS_TOKEN_VALID_MINUTE;
 import static com.renzzle.backend.domain.auth.service.JwtProvider.REFRESH_TOKEN_VALID_MINUTE;
 
@@ -83,7 +82,7 @@ public class AccountService {
                 .build();
     }
 
-    public boolean verifyLoginInfo(String email, String password) {
+    public Long verifyLoginInfo(String email, String password) {
         Optional<UserEntity> user = userRepository.findByEmail(email);
 
         if(user.isEmpty())
@@ -92,7 +91,7 @@ public class AccountService {
         if(!passwordEncoder.matches(password, user.get().getPassword()))
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
 
-        return true;
+        return user.get().getId();
     }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Optional;
+
 import static com.renzzle.backend.domain.auth.service.JwtProvider.ACCESS_TOKEN_VALID_MINUTE;
 import static com.renzzle.backend.domain.auth.service.JwtProvider.REFRESH_TOKEN_VALID_MINUTE;
 
@@ -79,6 +81,18 @@ public class AccountService {
                 .accessTokenExpiredAt(accessTokenExpiredAt)
                 .refreshTokenExpiredAt(refreshTokenExpiredAt)
                 .build();
+    }
+
+    public boolean verifyLoginInfo(String email, String password) {
+        Optional<UserEntity> user = userRepository.findByEmail(email);
+
+        if(user.isEmpty())
+            throw new CustomException(ErrorCode.INVALID_EMAIL);
+
+        if(!passwordEncoder.matches(password, user.get().getPassword()))
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
+
+        return true;
     }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
@@ -1,16 +1,84 @@
 package com.renzzle.backend.domain.auth.service;
 
+import com.renzzle.backend.domain.auth.api.response.LoginResponse;
+import com.renzzle.backend.domain.auth.dao.RefreshTokenRedisRepository;
+import com.renzzle.backend.domain.auth.domain.RefreshTokenEntity;
+import com.renzzle.backend.domain.user.dao.UserRepository;
+import com.renzzle.backend.domain.user.domain.UserEntity;
+import com.renzzle.backend.global.exception.CustomException;
+import com.renzzle.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.Duration;
+import java.time.Instant;
+import static com.renzzle.backend.domain.auth.service.JwtProvider.ACCESS_TOKEN_VALID_MINUTE;
+import static com.renzzle.backend.domain.auth.service.JwtProvider.REFRESH_TOKEN_VALID_MINUTE;
 
 @Service
 @RequiredArgsConstructor
 public class AccountService {
 
+    private final UserRepository userRepository;
+    private final RefreshTokenRedisRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
+    private final PasswordEncoder passwordEncoder;
 
     public String createAuthVerityToken(String email) {
         return jwtProvider.createAuthVerityToken(email);
+    }
+
+    public boolean verifyAuthVerityToken(String token, String email) {
+        String tokenValue = jwtProvider.getEmail(token);
+        return tokenValue.equals(email);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isDuplicatedEmail(String email) {
+        return userRepository.existsByEmail(email);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isDuplicateNickname(String nickname) {
+        return userRepository.existsByNickname(nickname);
+    }
+
+    @Transactional
+    public Long createNewUser(String email, String password, String nickname) {
+        // validate email
+        if(isDuplicatedEmail(email))
+            throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+
+        String encodedPassword = passwordEncoder.encode(password);
+
+        UserEntity user = UserEntity.builder()
+                .email(email)
+                .password(encodedPassword)
+                .nickname(nickname)
+                .build();
+        return userRepository.save(user).getId();
+    }
+
+    public LoginResponse createAuthTokens(Long id) {
+        String grantType = "Bearer";
+        String accessToken = jwtProvider.createAccessToken(id);
+        String refreshToken = jwtProvider.createRefreshToken(id);
+        Instant accessTokenExpiredAt = Instant.now().plus(Duration.ofMinutes(ACCESS_TOKEN_VALID_MINUTE));
+        Instant refreshTokenExpiredAt = Instant.now().plus(Duration.ofMinutes(REFRESH_TOKEN_VALID_MINUTE));
+
+        refreshTokenRepository.save(RefreshTokenEntity.builder()
+                .id(id)
+                .token(refreshToken)
+                .build());
+
+        return LoginResponse.builder()
+                .grantType(grantType)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .accessTokenExpiredAt(accessTokenExpiredAt)
+                .refreshTokenExpiredAt(refreshTokenExpiredAt)
+                .build();
     }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
@@ -8,6 +8,7 @@ import com.renzzle.backend.domain.user.domain.UserEntity;
 import com.renzzle.backend.global.exception.CustomException;
 import com.renzzle.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,7 +25,7 @@ public class AccountService {
     private final UserRepository userRepository;
     private final RefreshTokenRedisRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
-    private final PasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
     public String createAuthVerityToken(String email) {
         return jwtProvider.createAuthVerityToken(email);
@@ -82,6 +83,7 @@ public class AccountService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
     public Long verifyLoginInfo(String email, String password) {
         Optional<UserEntity> user = userRepository.findByEmail(email);
 

--- a/src/main/java/com/renzzle/backend/domain/auth/service/EmailService.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/EmailService.java
@@ -19,6 +19,9 @@ import java.util.Random;
 @RequiredArgsConstructor
 public class EmailService {
 
+    public static final int EMAIL_CODE_VALID_MINUTE = 5;
+    public static final int EMAIL_VERIFICATION_LIMIT = 5;
+
     private final JavaMailSender javaMailSender;
     private final SpringTemplateEngine templateEngine;
     private final EmailRedisRepository emailRepository;
@@ -89,7 +92,7 @@ public class EmailService {
             Instant issuedAt = Instant.parse(emailEntity.get().issuedAt());
 
             Duration duration = Duration.between(issuedAt, now);
-            if (duration.toMinutes() > 5) {
+            if (duration.toMinutes() > EMAIL_CODE_VALID_MINUTE) {
                 return false;
             }
         }

--- a/src/main/java/com/renzzle/backend/domain/auth/service/JwtProvider.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/JwtProvider.java
@@ -15,6 +15,10 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class JwtProvider {
 
+    public static final int ACCESS_TOKEN_VALID_MINUTE = 60;
+    public static final int REFRESH_TOKEN_VALID_MINUTE = 60 * 24 * 14;
+    public static final int AUTH_VERITY_TOKEN_VALID_MINUTE = 5;
+
     private final String CLAIM_USER_ID_KEY = "userId";
     private final String CLAIM_EMAIL_KEY = "email";
     private final SecretKey secretKey;
@@ -51,15 +55,15 @@ public class JwtProvider {
     }
 
     public String createAccessToken(long userId) {
-        return createToken(Map.of(CLAIM_USER_ID_KEY, userId), 60);
+        return createToken(Map.of(CLAIM_USER_ID_KEY, userId), ACCESS_TOKEN_VALID_MINUTE);
     }
 
     public String createRefreshToken(long userId) {
-        return createToken(Map.of(CLAIM_USER_ID_KEY, userId), 60 * 24 * 14);
+        return createToken(Map.of(CLAIM_USER_ID_KEY, userId), REFRESH_TOKEN_VALID_MINUTE);
     }
 
     public String createAuthVerityToken(String email) {
-        return createToken(Map.of(CLAIM_EMAIL_KEY, email), 5);
+        return createToken(Map.of(CLAIM_EMAIL_KEY, email), AUTH_VERITY_TOKEN_VALID_MINUTE);
     }
 
     public long getUserId(String token) {

--- a/src/main/java/com/renzzle/backend/domain/auth/service/JwtProvider.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/JwtProvider.java
@@ -3,11 +3,16 @@ package com.renzzle.backend.domain.auth.service;
 import com.renzzle.backend.global.exception.CustomException;
 import com.renzzle.backend.global.exception.ErrorCode;
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SecurityException;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Map;
 
@@ -21,7 +26,15 @@ public class JwtProvider {
 
     private final String CLAIM_USER_ID_KEY = "userId";
     private final String CLAIM_EMAIL_KEY = "email";
-    private final SecretKey secretKey;
+
+    @Value("${JWT_SECRET_KEY}")
+    private String JWT_SECRET_KEY;
+    private SecretKey secretKey;
+
+    @PostConstruct
+    public void init() {
+        this.secretKey = Keys.hmacShaKeyFor(JWT_SECRET_KEY.getBytes(StandardCharsets.UTF_8));
+    }
 
     private String createToken(Map<String, Object> claims, int validMin) {
         Date now = new Date();

--- a/src/main/java/com/renzzle/backend/domain/test/api/TestController.java
+++ b/src/main/java/com/renzzle/backend/domain/test/api/TestController.java
@@ -7,7 +7,7 @@ import com.renzzle.backend.domain.test.api.response.SaveEntityResponse;
 import com.renzzle.backend.domain.test.domain.JdbcEntity;
 import com.renzzle.backend.domain.test.domain.TestEntity;
 import com.renzzle.backend.domain.test.service.TestService;
-import com.renzzle.backend.global.common.ApiResponse;
+import com.renzzle.backend.global.common.response.ApiResponse;
 import com.renzzle.backend.global.util.ApiUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/renzzle/backend/domain/test/api/TestController.java
+++ b/src/main/java/com/renzzle/backend/domain/test/api/TestController.java
@@ -56,8 +56,8 @@ public class TestController {
     }
 
     @Operation(summary = "Server DB test", description = "Test finding entity on DB through JPA")
-    @GetMapping("/find/jpa/{Id}")
-    public ApiResponse<FindEntityResponse> findTestEntity(@PathVariable("Id") Long id) {
+    @GetMapping("/find/jpa/{id}")
+    public ApiResponse<FindEntityResponse> findTestEntity(@PathVariable("id") Long id) {
         TestEntity result = testService.findEntityById(id);
 
         FindEntityResponse response = FindEntityResponse
@@ -88,8 +88,8 @@ public class TestController {
     }
 
     @Operation(summary = "Server DB test", description = "Test finding entity on DB through JDBC")
-    @GetMapping("/find/jdbc/{Id}")
-    public ApiResponse<FindEntityResponse> findJdbcEntity(@PathVariable("Id") Long id) {
+    @GetMapping("/find/jdbc/{id}")
+    public ApiResponse<FindEntityResponse> findJdbcEntity(@PathVariable("id") Long id) {
         JdbcEntity result = testService.findJdbcEntityById(id);
 
         FindEntityResponse response = FindEntityResponse

--- a/src/main/java/com/renzzle/backend/domain/test/api/TestController.java
+++ b/src/main/java/com/renzzle/backend/domain/test/api/TestController.java
@@ -21,7 +21,7 @@ import static com.renzzle.backend.global.util.BindingResultUtils.getErrorMessage
 @RestController
 @RequestMapping("/api/test")
 @RequiredArgsConstructor
-@Tag(name = "Test API", description = "server testing api")
+@Tag(name = "Test API", description = "Server testing API")
 public class TestController {
 
     private final TestService testService;

--- a/src/main/java/com/renzzle/backend/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/user/dao/UserRepository.java
@@ -1,0 +1,12 @@
+package com.renzzle.backend.domain.user.dao;
+
+import com.renzzle.backend.domain.user.domain.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
+
+}

--- a/src/main/java/com/renzzle/backend/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/user/dao/UserRepository.java
@@ -3,10 +3,14 @@ package com.renzzle.backend.domain.user.dao;
 import com.renzzle.backend.domain.user.domain.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);
+
+    Optional<UserEntity> findByEmail(String email);
 
 }

--- a/src/main/java/com/renzzle/backend/domain/user/domain/Color.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/Color.java
@@ -24,7 +24,7 @@ public class Color {
     }
 
     public enum ColorName {
-        RED, RANGE, GREEN, BLUE, INDIGO, PURPLE,
+        RED, ORANGE, GREEN, BLUE, INDIGO, PURPLE,
         DARK_RED, DARK_ORANGE, DARK_GREEN,
         DARK_BLUE, DARK_INDIGO, DARK_PURPLE
     }

--- a/src/main/java/com/renzzle/backend/domain/user/domain/Color.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/Color.java
@@ -1,0 +1,40 @@
+package com.renzzle.backend.domain.user.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import java.util.Random;
+
+@Entity
+@Table(name = "color")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Color {
+
+    private static final Random RANDOM = new Random();
+
+    @Id
+    @Column(length = 31)
+    private String name;
+
+    private Color(String name) {
+        this.name = name;
+    }
+
+    public enum ColorName {
+        RED, RANGE, GREEN, BLUE, INDIGO, PURPLE,
+        DARK_RED, DARK_ORANGE, DARK_GREEN,
+        DARK_BLUE, DARK_INDIGO, DARK_PURPLE
+    }
+
+    public static Color getRandomColor() {
+        ColorName[] colorNames = ColorName.values();
+        int randomIdx = RANDOM.nextInt(colorNames.length);
+        ColorName randomColorName = colorNames[randomIdx];
+
+        return new Color(randomColorName.name());
+    }
+
+}

--- a/src/main/java/com/renzzle/backend/domain/user/domain/Level.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/Level.java
@@ -1,0 +1,48 @@
+package com.renzzle.backend.domain.user.domain;
+
+import com.renzzle.backend.global.exception.CustomException;
+import com.renzzle.backend.global.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import java.util.Arrays;
+
+@Entity
+@Table(name = "level")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Level {
+
+    @Id
+    @Column(length = 31)
+    private String name;
+
+    private Level(String name) {
+        this.name = name;
+    }
+
+    public enum LevelName {
+        BEGINNER, INTERMEDIATE, ADVANCED
+    }
+
+    public static Level getDefaultLevel() {
+        return new Level(LevelName.BEGINNER.name());
+    }
+
+    public void setLevel(String levelName) {
+        LevelName[] levelNames = LevelName.values();
+        boolean isValid = Arrays.stream(levelNames)
+                .anyMatch(level -> level.name().equals(levelName));
+        if(!isValid)
+            throw new CustomException(ErrorCode.VALIDATION_ERROR);
+
+        this.name = levelName;
+    }
+
+    public void setLevel(LevelName levelName) {
+        this.name = levelName.name();
+    }
+
+}

--- a/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
@@ -8,6 +8,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.time.Instant;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder(toBuilder = true)

--- a/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
@@ -1,0 +1,63 @@
+package com.renzzle.backend.domain.user.domain;
+
+import com.renzzle.backend.global.common.domain.Status;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.time.Instant;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Table(name = "user")
+public class UserEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, length = 15)
+    private String nickname;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @ManyToOne
+    @JoinColumn(name = "status", nullable = false)
+    private Status status;
+
+    @ManyToOne
+    @JoinColumn(name = "color", nullable = false)
+    private Color color;
+
+    @ManyToOne
+    @JoinColumn(name = "level", nullable = false)
+    private Level level;
+
+    @PrePersist
+    public void prePersist() {
+        if (status == null) {
+            this.status = Status.getDefaultStatus();
+        }
+        if (color == null) {
+            this.color = Color.getRandomColor();
+        }
+        if (level == null) {
+            this.level = Level.getDefaultLevel();
+        }
+    }
+
+}

--- a/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
@@ -25,15 +25,15 @@ public class UserEntity {
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false, length = 15)
+    @Column(nullable = false, unique = true, length = 15)
     private String nickname;
 
     @CreationTimestamp
-    @Column(name = "created_at", updatable = false)
+    @Column(name = "created_at", updatable = false, nullable = false)
     private Instant createdAt;
 
     @UpdateTimestamp
-    @Column(name = "updated_at")
+    @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
     @ManyToOne

--- a/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
@@ -46,7 +46,7 @@ public class UserEntity {
 
     @ManyToOne
     @JoinColumn(name = "level", nullable = false)
-    private Level level;
+    private UserLevel level;
 
     @PrePersist
     public void prePersist() {
@@ -57,7 +57,7 @@ public class UserEntity {
             this.color = Color.getRandomColor();
         }
         if (level == null) {
-            this.level = Level.getDefaultLevel();
+            this.level = UserLevel.getDefaultLevel();
         }
     }
 

--- a/src/main/java/com/renzzle/backend/domain/user/domain/UserLevel.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/UserLevel.java
@@ -11,15 +11,15 @@ import lombok.NoArgsConstructor;
 import java.util.Arrays;
 
 @Entity
-@Table(name = "level")
+@Table(name = "user_level")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Level {
+public class UserLevel {
 
     @Id
     @Column(length = 31)
     private String name;
 
-    private Level(String name) {
+    private UserLevel(String name) {
         this.name = name;
     }
 
@@ -27,8 +27,8 @@ public class Level {
         BEGINNER, INTERMEDIATE, ADVANCED
     }
 
-    public static Level getDefaultLevel() {
-        return new Level(LevelName.BEGINNER.name());
+    public static UserLevel getDefaultLevel() {
+        return new UserLevel(LevelName.BEGINNER.name());
     }
 
     public void setLevel(String levelName) {

--- a/src/main/java/com/renzzle/backend/global/common/domain/Status.java
+++ b/src/main/java/com/renzzle/backend/global/common/domain/Status.java
@@ -1,0 +1,35 @@
+package com.renzzle.backend.global.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "status")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Status {
+
+    @Id
+    @Column(length = 31)
+    private String name;
+
+    private Status(String name) {
+        this.name = name;
+    }
+
+    public enum StatusName {
+        CREATED, DELETED
+    }
+
+    public static Status getDefaultStatus() {
+        return new Status(StatusName.CREATED.name());
+    }
+
+    public void setStatus(StatusName statusName) {
+        this.name = statusName.name();
+    }
+
+}

--- a/src/main/java/com/renzzle/backend/global/common/response/ApiResponse.java
+++ b/src/main/java/com/renzzle/backend/global/common/response/ApiResponse.java
@@ -1,10 +1,8 @@
-package com.renzzle.backend.global.common;
+package com.renzzle.backend.global.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.renzzle.backend.global.exception.ErrorResponse;
-import lombok.Getter;
-import lombok.Setter;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public record ApiResponse<T>(@JsonProperty("isSuccess") Boolean isSuccess,

--- a/src/main/java/com/renzzle/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/renzzle/backend/global/config/SecurityConfig.java
@@ -20,20 +20,6 @@ import java.nio.charset.StandardCharsets;
 @EnableWebSecurity
 public class SecurityConfig {
 
-    @Value("${JWT_SECRET_KEY}")
-    private String JWT_SECRET_KEY;
-
-    // for jwt provider
-    @Bean
-    public SecretKey secretKey() {
-        return Keys.hmacShaKeyFor(JWT_SECRET_KEY.getBytes(StandardCharsets.UTF_8));
-    }
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity.csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
@@ -20,6 +20,8 @@ public enum ErrorCode {
     EXCEED_EMAIL_AUTH_REQUEST(HttpStatus.TOO_MANY_REQUESTS, "A429", "이메일 인증 횟수를 초과했습니다."),
     NOT_VALID_CODE(HttpStatus.BAD_REQUEST, "A4000", "유효하지 않은 인증코드입니다."),
     INVALID_AUTH_VERITY_TOKEN(HttpStatus.BAD_REQUEST, "A4001", "유효하지 않은 회원가입 인증 토큰입니다."),
+    INVALID_EMAIL(HttpStatus.BAD_REQUEST, "A4002", "유효하지 않은 이메일입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "A4003", "유효하지 않은 비밀번호입니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "A409", "이미 존재하는 이메일입니다."),
 
     // Jwt

--- a/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
@@ -25,7 +25,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "A409", "이미 존재하는 이메일입니다."),
 
     // Jwt
-    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J4010", "만료된 토큰입니다."),
+    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J401", "만료된 토큰입니다."),
     MALFORMED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "J4001", "손상되었거나 잘못된 형식의 토큰입니다."),
     UNSUPPORTED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "J4002", "지원하지 않는 형식의 토큰입니다."),
     ILLEGAL_TOKEN(HttpStatus.BAD_REQUEST, "J4003", "토큰이 없거나 잘못된 형식의 토큰입니다."),

--- a/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
@@ -22,7 +22,8 @@ public enum ErrorCode {
     INVALID_AUTH_VERITY_TOKEN(HttpStatus.BAD_REQUEST, "A4001", "유효하지 않은 회원가입 인증 토큰입니다."),
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "A4002", "유효하지 않은 이메일입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "A4003", "유효하지 않은 비밀번호입니다."),
-    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "A409", "이미 존재하는 이메일입니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "A4090", "이미 존재하는 이메일입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "A4091", "이미 존재하는 닉네임입니다."),
 
     // Jwt
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J401", "만료된 토큰입니다."),

--- a/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
@@ -26,10 +26,10 @@ public enum ErrorCode {
 
     // Jwt
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J401", "만료된 토큰입니다."),
-    MALFORMED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "J4001", "손상되었거나 잘못된 형식의 토큰입니다."),
-    UNSUPPORTED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "J4002", "지원하지 않는 형식의 토큰입니다."),
-    ILLEGAL_TOKEN(HttpStatus.BAD_REQUEST, "J4003", "토큰이 없거나 잘못된 형식의 토큰입니다."),
-    CANNOT_PARSE_TOKEN(HttpStatus.BAD_REQUEST, "J4004", "토큰 파싱에 실패하였습니다.");
+    MALFORMED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "J4000", "손상되었거나 잘못된 형식의 토큰입니다."),
+    UNSUPPORTED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "J4001", "지원하지 않는 형식의 토큰입니다."),
+    ILLEGAL_TOKEN(HttpStatus.BAD_REQUEST, "J4002", "토큰이 없거나 잘못된 형식의 토큰입니다."),
+    CANNOT_PARSE_TOKEN(HttpStatus.BAD_REQUEST, "J4003", "토큰 파싱에 실패하였습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
@@ -18,7 +18,7 @@ public enum ErrorCode {
 
     // Auth
     EXCEED_EMAIL_AUTH_REQUEST(HttpStatus.TOO_MANY_REQUESTS, "A429", "이메일 인증 횟수를 초과했습니다."),
-    NOT_VALID_CODE(HttpStatus.BAD_REQUEST, "A4000", "유효하지 않은 인증코드입니다."),
+    INVALID_EMAIL_AUTH_CODE(HttpStatus.BAD_REQUEST, "A4000", "유효하지 않은 인증코드입니다."),
     INVALID_AUTH_VERITY_TOKEN(HttpStatus.BAD_REQUEST, "A4001", "유효하지 않은 회원가입 인증 토큰입니다."),
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "A4002", "유효하지 않은 이메일입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "A4003", "유효하지 않은 비밀번호입니다."),

--- a/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
@@ -18,7 +18,9 @@ public enum ErrorCode {
 
     // Auth
     EXCEED_EMAIL_AUTH_REQUEST(HttpStatus.TOO_MANY_REQUESTS, "A429", "이메일 인증 횟수를 초과했습니다."),
-    NOT_VALID_CODE(HttpStatus.BAD_REQUEST, "A400", "유효하지 않은 인증코드입니다."),
+    NOT_VALID_CODE(HttpStatus.BAD_REQUEST, "A4000", "유효하지 않은 인증코드입니다."),
+    INVALID_AUTH_VERITY_TOKEN(HttpStatus.BAD_REQUEST, "A4001", "유효하지 않은 회원가입 인증 토큰입니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "A409", "이미 존재하는 이메일입니다."),
 
     // Jwt
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J4010", "만료된 토큰입니다."),

--- a/src/main/java/com/renzzle/backend/global/init/DataInitializer.java
+++ b/src/main/java/com/renzzle/backend/global/init/DataInitializer.java
@@ -1,0 +1,26 @@
+package com.renzzle.backend.global.init;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements CommandLineRunner {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void run(String... args) {
+        String statusSql = "INSERT INTO status (name) VALUES ('CREATED'), ('DELETED')";
+        jdbcTemplate.execute(statusSql);
+
+        String userLevelSql = "INSERT INTO user_level (name) VALUES ('BEGINNER'), ('INTERMEDIATE'), ('ADVANCED')";
+        jdbcTemplate.execute(userLevelSql);
+
+        String colorSql = "INSERT INTO color (name) VALUES ('RED'), ('ORANGE'), ('GREEN'), ('BLUE'), ('INDIGO'), ('PURPLE'), ('DARK_RED'), ('DARK_ORANGE'), ('DARK_GREEN'), ('DARK_BLUE'), ('DARK_INDIGO'), ('DARK_PURPLE')";
+        jdbcTemplate.execute(colorSql);
+    }
+
+}

--- a/src/main/java/com/renzzle/backend/global/init/DataInitializer.java
+++ b/src/main/java/com/renzzle/backend/global/init/DataInitializer.java
@@ -1,10 +1,13 @@
 package com.renzzle.backend.global.init;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class DataInitializer implements CommandLineRunner {
@@ -13,14 +16,18 @@ public class DataInitializer implements CommandLineRunner {
 
     @Override
     public void run(String... args) {
-        String statusSql = "INSERT INTO status (name) VALUES ('CREATED'), ('DELETED')";
-        jdbcTemplate.execute(statusSql);
+        try {
+            String statusSql = "INSERT INTO status (name) VALUES ('CREATED'), ('DELETED')";
+            jdbcTemplate.execute(statusSql);
 
-        String userLevelSql = "INSERT INTO user_level (name) VALUES ('BEGINNER'), ('INTERMEDIATE'), ('ADVANCED')";
-        jdbcTemplate.execute(userLevelSql);
+            String userLevelSql = "INSERT INTO user_level (name) VALUES ('BEGINNER'), ('INTERMEDIATE'), ('ADVANCED')";
+            jdbcTemplate.execute(userLevelSql);
 
-        String colorSql = "INSERT INTO color (name) VALUES ('RED'), ('ORANGE'), ('GREEN'), ('BLUE'), ('INDIGO'), ('PURPLE'), ('DARK_RED'), ('DARK_ORANGE'), ('DARK_GREEN'), ('DARK_BLUE'), ('DARK_INDIGO'), ('DARK_PURPLE')";
-        jdbcTemplate.execute(colorSql);
+            String colorSql = "INSERT INTO color (name) VALUES ('RED'), ('ORANGE'), ('GREEN'), ('BLUE'), ('INDIGO'), ('PURPLE'), ('DARK_RED'), ('DARK_ORANGE'), ('DARK_GREEN'), ('DARK_BLUE'), ('DARK_INDIGO'), ('DARK_PURPLE')";
+            jdbcTemplate.execute(colorSql);
+        } catch(DuplicateKeyException e) {
+            log.warn("Data already exists");
+        }
     }
 
 }

--- a/src/main/java/com/renzzle/backend/global/util/ApiUtils.java
+++ b/src/main/java/com/renzzle/backend/global/util/ApiUtils.java
@@ -1,6 +1,6 @@
 package com.renzzle.backend.global.util;
 
-import com.renzzle.backend.global.common.ApiResponse;
+import com.renzzle.backend.global.common.response.ApiResponse;
 import com.renzzle.backend.global.exception.ErrorResponse;
 import org.springframework.http.ResponseEntity;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,13 +7,14 @@ spring:
     username: ${DB_USER}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    initialization-mode: always
 
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
     open-in-view: true
     show-sql: true
     hibernate:
-      hbm2ddl.auto: update
+      ddl-auto: update
       dialect: org.hibernate.dialect.MySQLDialect
     properties:
       hibernate:


### PR DESCRIPTION
### ✏️ 작업 개요
유저 관련 Auth API 작업

### 🔨 작업 상세 내용
1. User Repository 생성 -> DB에 User 관련 테이블 추가 (자동 추가)
2. Data Initializer 추가 -> DB에 초기 데이터 생성 (Status, Level, Color 같은)
3. 회원가입 API 완성
4. 로그인 API 완성
5. 닉네임 중복 체크 API 완성
6. 이메일 인증 요청 시 이미 가입된 이메일이면 에러 처리 추가
7. 회원가입 / 로그인 시 발생하는 에러 응답 추가

### 💡 생각해볼 문제
- Transactional 잘 사용하기 (Redis에는 Transactional 적용이 힘듬 -> 오류 발생 시 대처 필요)
- Token에 관한 더 깊은 이해 (GrantType은 무엇인가? 등)
- JPA에 대한 고민들 (외래키로 자동으로 해당 Entity를 불러오면서 생기는 문제들 등)
- level 테이블 명을 user_level로 변경 (level이 DB의 예약어) 
