### PR TITLE
로그아웃 & 토큰 재발급 API / Spring Security jwt filter 작업

### DIFF
--- a/src/main/java/com/renzzle/backend/domain/auth/api/AuthController.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/AuthController.java
@@ -1,9 +1,6 @@
 package com.renzzle.backend.domain.auth.api;
 
-import com.renzzle.backend.domain.auth.api.request.AuthEmailRequest;
-import com.renzzle.backend.domain.auth.api.request.ConfirmCodeRequest;
-import com.renzzle.backend.domain.auth.api.request.LoginRequest;
-import com.renzzle.backend.domain.auth.api.request.SignupRequest;
+import com.renzzle.backend.domain.auth.api.request.*;
 import com.renzzle.backend.domain.auth.api.response.AuthEmailResponse;
 import com.renzzle.backend.domain.auth.api.response.ConfirmCodeResponse;
 import com.renzzle.backend.domain.auth.api.response.LoginResponse;
@@ -12,12 +9,14 @@ import com.renzzle.backend.domain.auth.service.EmailService;
 import com.renzzle.backend.global.common.response.ApiResponse;
 import com.renzzle.backend.global.exception.CustomException;
 import com.renzzle.backend.global.exception.ErrorCode;
+import com.renzzle.backend.global.security.UserDetailsImpl;
 import com.renzzle.backend.global.util.ApiUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.ValidationException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
@@ -111,6 +110,22 @@ public class AuthController {
         long userId = accountService.verifyLoginInfo(request.email(), request.password());
 
         return ApiUtils.success(accountService.createAuthTokens(userId));
+    }
+
+    @Operation(summary = "Logout to service", description = "Delete the refresh token to prevent reissuing the authentication tokens")
+    @PostMapping("/logout")
+    public ApiResponse<Long> logout(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        Long id = accountService.deleteRefreshToken(userDetails.getUser().getId());
+        return ApiUtils.success(id);
+    }
+
+    @Operation(summary = "Reissue authentication tokens", description = "Issue authentication tokens for server access")
+    @PostMapping("/reissueToken")
+    public ApiResponse<LoginResponse> reissueToken(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody ReissueTokenRequest request) {
+        if(!accountService.verifyRefreshToken(request.refreshToken()))
+            throw new CustomException(ErrorCode.EXPIRED_JWT_TOKEN);
+
+        return ApiUtils.success(accountService.createAuthTokens(userDetails.getUser().getId()));
     }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/ReissueTokenRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/ReissueTokenRequest.java
@@ -1,0 +1,5 @@
+package com.renzzle.backend.domain.auth.api.request;
+
+public record ReissueTokenRequest(
+        String refreshToken
+) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/domain/GrantType.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/domain/GrantType.java
@@ -1,0 +1,14 @@
+package com.renzzle.backend.domain.auth.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GrantType {
+
+    BEARER("Bearer");
+
+    private final String type;
+
+}

--- a/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
@@ -2,6 +2,7 @@ package com.renzzle.backend.domain.auth.service;
 
 import com.renzzle.backend.domain.auth.api.response.LoginResponse;
 import com.renzzle.backend.domain.auth.dao.RefreshTokenRedisRepository;
+import com.renzzle.backend.domain.auth.domain.GrantType;
 import com.renzzle.backend.domain.auth.domain.RefreshTokenEntity;
 import com.renzzle.backend.domain.user.dao.UserRepository;
 import com.renzzle.backend.domain.user.domain.UserEntity;
@@ -67,7 +68,7 @@ public class AccountService {
     }
 
     public LoginResponse createAuthTokens(Long id) {
-        String grantType = "Bearer";
+        String grantType = GrantType.BEARER.getType();
         String accessToken = jwtProvider.createAccessToken(id);
         String refreshToken = jwtProvider.createRefreshToken(id);
         Instant accessTokenExpiredAt = Instant.now().plus(Duration.ofMinutes(ACCESS_TOKEN_VALID_MINUTE));

--- a/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
@@ -101,4 +101,16 @@ public class AccountService {
         return user.get().getId();
     }
 
+    public Long deleteRefreshToken(Long id) {
+        refreshTokenRepository.deleteById(id);
+        return id;
+    }
+
+    public boolean verifyRefreshToken(String token) {
+        Long userId = jwtProvider.getUserId(token);
+        Optional<RefreshTokenEntity> tokenEntity = refreshTokenRepository.findById(userId);
+
+        return tokenEntity.isPresent();
+    }
+
 }

--- a/src/main/java/com/renzzle/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/renzzle/backend/global/config/SecurityConfig.java
@@ -1,33 +1,59 @@
 package com.renzzle.backend.global.config;
 
-import io.jsonwebtoken.security.Keys;
-import org.springframework.beans.factory.annotation.Value;
+import com.renzzle.backend.domain.auth.service.JwtProvider;
+import com.renzzle.backend.domain.user.dao.UserRepository;
+import com.renzzle.backend.global.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-
-import javax.crypto.SecretKey;
-import java.nio.charset.StandardCharsets;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
-        httpSecurity.csrf(AbstractHttpConfigurer::disable)
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        List<RequestMatcher> permitAllRequestMatchers = Arrays.asList(
+                AntPathRequestMatcher.antMatcher("/"),
+                AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/api/test/**"),
+                AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/api/test/**"),
+                AntPathRequestMatcher.antMatcher(HttpMethod.DELETE, "/api/test/**"),
+                AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/api/auth/email"),
+                AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/api/auth/confirmCode"),
+                AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/api/auth/duplicate/**"),
+                AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/api/auth/signup"),
+                AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/swagger-ui/**"),
+                AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/v3/api-docs/**")
+        );
+
+        return httpSecurity.csrf(AbstractHttpConfigurer::disable)
                 .formLogin(FormLoginConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement((sessionManagement) ->
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                );
-        return httpSecurity.build();
+                )
+                .authorizeHttpRequests(request -> request
+                        .requestMatchers(permitAllRequestMatchers.toArray(new RequestMatcher[0])).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, userRepository, permitAllRequestMatchers), UsernamePasswordAuthenticationFilter.class)
+                .build();
     }
 
 }

--- a/src/main/java/com/renzzle/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/renzzle/backend/global/config/SecurityConfig.java
@@ -30,13 +30,11 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         List<RequestMatcher> permitAllRequestMatchers = Arrays.asList(
-                AntPathRequestMatcher.antMatcher("/"),
-                AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/api/test/**"),
-                AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/api/test/**"),
-                AntPathRequestMatcher.antMatcher(HttpMethod.DELETE, "/api/test/**"),
+                AntPathRequestMatcher.antMatcher("/api/test/**"),
                 AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/api/auth/email"),
                 AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/api/auth/confirmCode"),
                 AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/api/auth/duplicate/**"),
+                AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/api/auth/login"),
                 AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/api/auth/signup"),
                 AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/swagger-ui/**"),
                 AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/v3/api-docs/**")

--- a/src/main/java/com/renzzle/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/renzzle/backend/global/config/SwaggerConfig.java
@@ -1,8 +1,11 @@
 package com.renzzle.backend.global.config;
 
+import com.renzzle.backend.domain.auth.domain.GrantType;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,8 +14,22 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+        String jwtSchemeName = "Authorization";
+
+        SecurityRequirement securityRequirement = new SecurityRequirement();
+        securityRequirement.addList(jwtSchemeName);
+
+        SecurityScheme securityScheme = new SecurityScheme();
+        securityScheme.name(jwtSchemeName)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme(GrantType.BEARER.getType());
+
+        Components components = new Components();
+        components.addSecuritySchemes(jwtSchemeName, securityScheme);
+
         return new OpenAPI()
-                .components(new Components())
+                .addSecurityItem(securityRequirement)
+                .components(components)
                 .info(apiInfo());
     }
 

--- a/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
@@ -18,19 +18,20 @@ public enum ErrorCode {
 
     // Auth
     EXCEED_EMAIL_AUTH_REQUEST(HttpStatus.TOO_MANY_REQUESTS, "A429", "이메일 인증 횟수를 초과했습니다."),
-    INVALID_EMAIL_AUTH_CODE(HttpStatus.BAD_REQUEST, "A4000", "유효하지 않은 인증코드입니다."),
-    INVALID_AUTH_VERITY_TOKEN(HttpStatus.BAD_REQUEST, "A4001", "유효하지 않은 회원가입 인증 토큰입니다."),
-    INVALID_EMAIL(HttpStatus.BAD_REQUEST, "A4002", "유효하지 않은 이메일입니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "A4003", "유효하지 않은 비밀번호입니다."),
+    INVALID_EMAIL_AUTH_CODE(HttpStatus.UNAUTHORIZED, "A4010", "유효하지 않은 인증코드입니다."),
+    INVALID_AUTH_VERITY_TOKEN(HttpStatus.UNAUTHORIZED, "A4011", "유효하지 않은 회원가입 인증 토큰입니다."),
+    INVALID_EMAIL(HttpStatus.UNAUTHORIZED, "A4012", "유효하지 않은 이메일입니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "A4013", "유효하지 않은 비밀번호입니다."),
+    NOT_BEARER_GRANT_TYPE(HttpStatus.UNAUTHORIZED, "A4014", "인증 타입이 Bearer 타입이 아닙니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "A4090", "이미 존재하는 이메일입니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "A4091", "이미 존재하는 닉네임입니다."),
 
     // Jwt
-    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J401", "만료된 토큰입니다."),
-    MALFORMED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "J4000", "손상되었거나 잘못된 형식의 토큰입니다."),
-    UNSUPPORTED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "J4001", "지원하지 않는 형식의 토큰입니다."),
-    ILLEGAL_TOKEN(HttpStatus.BAD_REQUEST, "J4002", "토큰이 없거나 잘못된 형식의 토큰입니다."),
-    CANNOT_PARSE_TOKEN(HttpStatus.BAD_REQUEST, "J4003", "토큰 파싱에 실패하였습니다.");
+    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J4010", "만료된 토큰입니다."),
+    MALFORMED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J4011", "손상되었거나 잘못된 형식의 토큰입니다."),
+    UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J4012", "지원하지 않는 형식의 토큰입니다."),
+    ILLEGAL_TOKEN(HttpStatus.UNAUTHORIZED, "J4013", "토큰이 없거나 잘못된 형식의 토큰입니다."),
+    CANNOT_PARSE_TOKEN(HttpStatus.UNAUTHORIZED, "J4014", "토큰 파싱에 실패하였습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/renzzle/backend/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/renzzle/backend/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,94 @@
+package com.renzzle.backend.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.renzzle.backend.domain.auth.domain.GrantType;
+import com.renzzle.backend.domain.auth.service.JwtProvider;
+import com.renzzle.backend.domain.user.dao.UserRepository;
+import com.renzzle.backend.domain.user.domain.UserEntity;
+import com.renzzle.backend.global.common.response.ApiResponse;
+import com.renzzle.backend.global.exception.CustomException;
+import com.renzzle.backend.global.exception.ErrorCode;
+import com.renzzle.backend.global.exception.ErrorResponse;
+import jakarta.annotation.Nonnull;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+    private final List<RequestMatcher> permitAllRequestMatchers;
+
+    @Override
+    protected boolean shouldNotFilter(@Nonnull HttpServletRequest request) {
+        return permitAllRequestMatchers.stream().anyMatch(matcher -> matcher.matches(request));
+    }
+
+    @Override
+    protected void doFilterInternal(@Nonnull HttpServletRequest request, @Nonnull HttpServletResponse response, @Nonnull FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String accessToken = resolveToken(request);
+            Long userId = jwtProvider.getUserId(accessToken);
+            UserDetails userDetails = loadUserByUserId(userId);
+            Authentication authentication = UsernamePasswordAuthenticationToken.authenticated(userDetails, userDetails.getPassword(), userDetails.getAuthorities());
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            filterChain.doFilter(request, response);
+        } catch(CustomException e) {
+            handleException(response, e.getErrorCode());
+        } catch(Exception e) {
+            handleException(response, ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public UserDetails loadUserByUserId(Long userId) throws CustomException {
+        Optional<UserEntity> user = userRepository.findById(userId);
+        if(user.isEmpty())
+            throw new CustomException(ErrorCode.GLOBAL_NOT_FOUND);
+
+        return new UserDetailsImpl(user.get(), user.get().getPassword(), null);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if(!StringUtils.hasText(bearerToken)) {
+            throw new CustomException(ErrorCode.ILLEGAL_TOKEN);
+        }
+        if(!bearerToken.startsWith(GrantType.BEARER.getType())) {
+            throw new CustomException(ErrorCode.NOT_BEARER_GRANT_TYPE);
+        }
+        return bearerToken.substring(7);
+    }
+
+    private void handleException(HttpServletResponse response, ErrorCode errorCode) {
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        try {
+            ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+            ApiResponse<Object> objectApiResponse = ApiResponse.create(false, null, errorResponse);
+            String responseBody = new ObjectMapper().writeValueAsString(objectApiResponse);
+            response.getWriter().write(responseBody);
+        } catch(Exception e) {
+            log.error(e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/renzzle/backend/global/security/UserDetailsImpl.java
+++ b/src/main/java/com/renzzle/backend/global/security/UserDetailsImpl.java
@@ -1,0 +1,65 @@
+package com.renzzle.backend.global.security;
+
+import com.renzzle.backend.domain.user.domain.UserEntity;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public class UserDetailsImpl implements UserDetails {
+
+    @Getter
+    private final UserEntity user;
+    private final String password;
+    private final List<String> roles;
+
+    public UserDetailsImpl(UserEntity user, String password, List<String> roles) {
+        this.user = user;
+        this.password = password;
+        this.roles = roles;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        if (this.roles == null) {
+            return Collections.emptyList();
+        }
+        return this.roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}


### PR DESCRIPTION
### ✏️ 작업 개요
로그아웃 & 토큰 재발급 API 완성
Spring security를 활용한 인증 인가 구현

### 🔨 작업 상세 내용
1. Spring Security에 JWT 인증 filter 추가 (인증&인가 구현) -> Authorization Header에 Bearer Type의 Access Token을 넣어야 인가가 되도록 구현. 
2. Spring Security를 활용하여 @AuthenticationPrincipal 어노테이션으로 자동으로 토큰을 통해 유저 정보 불러오기 구현
3. /api/auth/logout API 완료
4. /api/auth/reissueToken API 완료

### 💡 생각해볼 문제
- Spring Security가 매우 복잡하므로 구조를 더 상세히 공부해둘 필요가 있음
- 지원하는 기능 중에 각 유저에게 role을 부여하는 기능이 있는데 추후 확장하면 좋을 듯 함  (어드민 등)
- filter chain은 permitAll() 메소드로 생략할 수 있는 줄 알았으나 그렇지 않음. permitAll()을 하더라도 모든 filter를 거침. 따라서 filter에서 try catch 문을 잘 활용해야함. (디버깅 완료)
- filter 쪽에서는 Exception Handler가 자동으로 Exception을 해결해주지 않으므로 따로 처리 필요 (구현 완료)
