### PR TITLE
커뮤니티 퍼즐 관련 API 작업

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# github-actions-test
-github action test 0814

--- a/src/main/java/com/renzzle/backend/domain/auth/api/AuthController.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/AuthController.java
@@ -6,6 +6,7 @@ import com.renzzle.backend.domain.auth.api.response.ConfirmCodeResponse;
 import com.renzzle.backend.domain.auth.api.response.LoginResponse;
 import com.renzzle.backend.domain.auth.service.AccountService;
 import com.renzzle.backend.domain.auth.service.EmailService;
+import com.renzzle.backend.domain.user.domain.UserEntity;
 import com.renzzle.backend.global.common.response.ApiResponse;
 import com.renzzle.backend.global.exception.CustomException;
 import com.renzzle.backend.global.exception.ErrorCode;
@@ -95,9 +96,9 @@ public class AuthController {
             throw new CustomException(ErrorCode.INVALID_AUTH_VERITY_TOKEN);
         }
 
-        Long userId = accountService.createNewUser(request.email(), request.password(), request.nickname());
+        UserEntity user = accountService.createNewUser(request.email(), request.password(), request.nickname());
 
-        return ApiUtils.success(accountService.createAuthTokens(userId));
+        return ApiUtils.success(accountService.createAuthTokens(user.getId()));
     }
 
     @Operation(summary = "Login to service", description = "Issue authentication tokens for server access")

--- a/src/main/java/com/renzzle/backend/domain/auth/api/AuthController.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/AuthController.java
@@ -22,7 +22,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import static com.renzzle.backend.domain.auth.service.EmailService.EMAIL_VERIFICATION_LIMIT;
-import static com.renzzle.backend.global.util.BindingResultUtils.getErrorMessages;
+import static com.renzzle.backend.global.util.ErrorUtils.getErrorMessages;
 
 @RestController
 @RequestMapping("/api/auth")

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/AuthEmailRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/AuthEmailRequest.java
@@ -1,10 +1,10 @@
 package com.renzzle.backend.domain.auth.api.request;
 
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 
 public record AuthEmailRequest(
-        @NotBlank(message = "이메일 정보가 없습니다")
+        @NotEmpty(message = "이메일 정보가 없습니다")
         @Email(message = "이메일 형식이 아닙니다")
         String email
 ) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/AuthEmailRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/AuthEmailRequest.java
@@ -1,8 +1,10 @@
 package com.renzzle.backend.domain.auth.api.request;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 
 public record AuthEmailRequest(
+        @NotBlank(message = "이메일 정보가 없습니다")
         @Email(message = "이메일 형식이 아닙니다")
         String email
 ) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/ConfirmCodeRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/ConfirmCodeRequest.java
@@ -1,11 +1,15 @@
 package com.renzzle.backend.domain.auth.api.request;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record ConfirmCodeRequest(
+        @NotBlank(message = "이메일 정보가 없습니다")
         @Email(message = "이메일 형식이 아닙니다")
         String email,
+
+        @NotBlank(message = "인증 코드 정보가 없습니다")
         @Pattern(regexp = "^\\d{6}$", message = "올바른 코드 형식이 아닙니다")
         String code
 ) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/ConfirmCodeRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/ConfirmCodeRequest.java
@@ -1,15 +1,15 @@
 package com.renzzle.backend.domain.auth.api.request;
 
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 
 public record ConfirmCodeRequest(
-        @NotBlank(message = "이메일 정보가 없습니다")
+        @NotEmpty(message = "이메일 정보가 없습니다")
         @Email(message = "이메일 형식이 아닙니다")
         String email,
 
-        @NotBlank(message = "인증 코드 정보가 없습니다")
+        @NotEmpty(message = "인증 코드 정보가 없습니다")
         @Pattern(regexp = "^\\d{6}$", message = "올바른 코드 형식이 아닙니다")
         String code
 ) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/LoginRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/LoginRequest.java
@@ -1,15 +1,15 @@
 package com.renzzle.backend.domain.auth.api.request;
 
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 
 public record LoginRequest(
-        @NotBlank(message = "이메일 정보가 없습니다")
+        @NotEmpty(message = "이메일 정보가 없습니다")
         @Email(message = "이메일 형식이 아닙니다")
         String email,
 
-        @NotBlank(message = "비밀번호 정보가 없습니다")
+        @NotEmpty(message = "비밀번호 정보가 없습니다")
         @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
         String password
 ) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/LoginRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/LoginRequest.java
@@ -10,6 +10,6 @@ public record LoginRequest(
         String email,
 
         @NotEmpty(message = "비밀번호 정보가 없습니다")
-        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
+        @Pattern(regexp = "^(?=.*[A-Za-z])[A-Za-z\\d]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
         String password
 ) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/LoginRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/LoginRequest.java
@@ -1,11 +1,15 @@
 package com.renzzle.backend.domain.auth.api.request;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record LoginRequest(
+        @NotBlank(message = "이메일 정보가 없습니다")
         @Email(message = "이메일 형식이 아닙니다")
         String email,
+
+        @NotBlank(message = "비밀번호 정보가 없습니다")
         @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
         String password
 ) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/ReissueTokenRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/ReissueTokenRequest.java
@@ -1,8 +1,8 @@
 package com.renzzle.backend.domain.auth.api.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 
 public record ReissueTokenRequest(
-        @NotBlank(message = "토큰 정보가 없습니다")
+        @NotEmpty(message = "토큰 정보가 없습니다")
         String refreshToken
 ) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/ReissueTokenRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/ReissueTokenRequest.java
@@ -1,5 +1,8 @@
 package com.renzzle.backend.domain.auth.api.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record ReissueTokenRequest(
+        @NotBlank(message = "토큰 정보가 없습니다")
         String refreshToken
 ) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/SignupRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/SignupRequest.java
@@ -11,7 +11,7 @@ public record SignupRequest(
         String email,
 
         @NotEmpty(message = "비밀번호 정보가 없습니다")
-        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
+        @Pattern(regexp = "^(?=.*[A-Za-z])[A-Za-z\\d]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
         String password,
 
         @NotEmpty(message = "닉네임 정보가 없습니다")

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/SignupRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/SignupRequest.java
@@ -1,15 +1,23 @@
 package com.renzzle.backend.domain.auth.api.request;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record SignupRequest(
+        @NotBlank(message = "이메일 정보가 없습니다")
         @Email(message = "이메일 형식이 아닙니다")
         String email,
+
+        @NotBlank(message = "비밀번호 정보가 없습니다")
         @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
         String password,
+
+        @NotBlank(message = "닉네임 정보가 없습니다")
         @Size(min = 2, max = 8, message = "닉네임은 2글자 이상, 최대 8글자까지 가능합니다")
         String nickname,
+
+        @NotBlank(message = "토큰 정보가 없습니다")
         String authVerityToken
 ) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/SignupRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/SignupRequest.java
@@ -1,24 +1,24 @@
 package com.renzzle.backend.domain.auth.api.request;
 
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record SignupRequest(
-        @NotBlank(message = "이메일 정보가 없습니다")
+        @NotEmpty(message = "이메일 정보가 없습니다")
         @Email(message = "이메일 형식이 아닙니다")
         String email,
 
-        @NotBlank(message = "비밀번호 정보가 없습니다")
+        @NotEmpty(message = "비밀번호 정보가 없습니다")
         @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
         String password,
 
-        @NotBlank(message = "닉네임 정보가 없습니다")
+        @NotEmpty(message = "닉네임 정보가 없습니다")
         @Pattern(regexp = "^[\\p{L}0-9]*$", message = "닉네임은 특수문자를 포함할 수 없습니다")
         @Size(min = 2, max = 8, message = "닉네임은 2글자 이상, 최대 8글자까지 가능합니다")
         String nickname,
 
-        @NotBlank(message = "토큰 정보가 없습니다")
+        @NotEmpty(message = "토큰 정보가 없습니다")
         String authVerityToken
 ) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/SignupRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/SignupRequest.java
@@ -15,6 +15,7 @@ public record SignupRequest(
         String password,
 
         @NotBlank(message = "닉네임 정보가 없습니다")
+        @Pattern(regexp = "^[\\p{L}0-9]*$", message = "닉네임은 특수문자를 포함할 수 없습니다")
         @Size(min = 2, max = 8, message = "닉네임은 2글자 이상, 최대 8글자까지 가능합니다")
         String nickname,
 

--- a/src/main/java/com/renzzle/backend/domain/auth/dao/AdminRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/dao/AdminRepository.java
@@ -1,0 +1,11 @@
+package com.renzzle.backend.domain.auth.dao;
+
+import com.renzzle.backend.domain.auth.domain.Admin;
+import com.renzzle.backend.domain.user.domain.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    boolean existsByUser(UserEntity user);
+
+}

--- a/src/main/java/com/renzzle/backend/domain/auth/domain/Admin.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/domain/Admin.java
@@ -2,15 +2,15 @@ package com.renzzle.backend.domain.auth.domain;
 
 import com.renzzle.backend.domain.user.domain.UserEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Table(name = "admin")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Admin {
 

--- a/src/main/java/com/renzzle/backend/domain/auth/domain/Admin.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/domain/Admin.java
@@ -1,0 +1,28 @@
+package com.renzzle.backend.domain.auth.domain;
+
+import com.renzzle.backend.domain.user.domain.UserEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@Table(name = "admin")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Admin {
+
+    public static final String ADMIN = "ADMIN";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private UserEntity user;
+
+}

--- a/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
@@ -48,7 +48,7 @@ public class AccountService {
     }
 
     @Transactional
-    public Long createNewUser(String email, String password, String nickname) {
+    public UserEntity createNewUser(String email, String password, String nickname) {
         // validate email
         if(isDuplicatedEmail(email))
             throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
@@ -64,7 +64,7 @@ public class AccountService {
                 .password(encodedPassword)
                 .nickname(nickname)
                 .build();
-        return userRepository.save(user).getId();
+        return userRepository.save(user);
     }
 
     public LoginResponse createAuthTokens(Long id) {

--- a/src/main/java/com/renzzle/backend/domain/auth/service/EmailService.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/EmailService.java
@@ -26,7 +26,7 @@ public class EmailService {
     private final SpringTemplateEngine templateEngine;
     private final EmailRedisRepository emailRepository;
 
-    @Value("spring.mail.username")
+    @Value("${spring.mail.username}")
     private String senderEmail;
 
     private String generateRandomCode() {

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
@@ -2,6 +2,7 @@ package com.renzzle.backend.domain.puzzle.api;
 
 import com.renzzle.backend.domain.puzzle.api.request.AddCommunityPuzzleRequest;
 import com.renzzle.backend.domain.puzzle.api.request.CommunityPuzzleResultUpdateRequest;
+import com.renzzle.backend.domain.puzzle.api.request.GetCommunityPuzzleRequest;
 import com.renzzle.backend.domain.puzzle.api.response.AddPuzzleResponse;
 import com.renzzle.backend.domain.puzzle.api.response.GetCommunityPuzzleResponse;
 import com.renzzle.backend.domain.puzzle.service.CommunityService;
@@ -34,24 +35,18 @@ public class CommunityController {
     @Operation(summary = "Get community puzzle data", description = "Return community puzzle list")
     @GetMapping("/puzzle")
     public ApiResponse<List<GetCommunityPuzzleResponse>> getCommunityPuzzle(
-            @RequestParam(required = false) Long id,
-
-            @Min(value = 1, message = "size는 최소 1이어야 합니다")
-            @Max(value = 100, message = "size는 최대 100이어야 합니다")
-            @RequestParam(defaultValue = "10") Integer size,
-
-            @ValidEnum(enumClass = SortOption.class, message = "잘못된 sort 형식입니다")
-            @RequestParam(defaultValue = "RECOMMEND") String sort,
-
+            @ModelAttribute GetCommunityPuzzleRequest request,
             BindingResult bindingResult
     ) {
         if(bindingResult.hasErrors()) {
             throw new ValidationException(getErrorMessages(bindingResult));
         }
 
+        int size = (request.size() != null) ? request.size() : 10;
+        String sort = (request.sort() != null) ? request.sort() : SortOption.RECOMMEND.name();
         SortOption sortOption = SortOption.valueOf(sort);
 
-        return ApiUtils.success(communityService.getCommunityPuzzleList(id, size, sortOption));
+        return ApiUtils.success(communityService.getCommunityPuzzleList(request.id(), size, sortOption));
     }
 
     @Operation(summary = "Register new community puzzle", description = "Add new community puzzle")

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
@@ -1,10 +1,20 @@
 package com.renzzle.backend.domain.puzzle.api;
 
+import com.renzzle.backend.domain.puzzle.api.request.AddPuzzleRequest;
+import com.renzzle.backend.domain.puzzle.api.response.AddPuzzleResponse;
 import com.renzzle.backend.domain.puzzle.service.CommunityService;
+import com.renzzle.backend.global.common.response.ApiResponse;
+import com.renzzle.backend.global.util.ApiUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.ValidationException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import static com.renzzle.backend.global.util.BindingResultUtils.getErrorMessages;
 
 @RestController
 @RequestMapping("/api/community")
@@ -13,5 +23,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommunityController {
 
     private final CommunityService communityService;
+
+    @PostMapping("/puzzle")
+    public ApiResponse<AddPuzzleResponse> addPuzzle(@Valid @RequestBody AddPuzzleRequest request, BindingResult bindingResult) {
+        if(bindingResult.hasErrors()) {
+            throw new ValidationException(getErrorMessages(bindingResult));
+        }
+        return ApiUtils.success(null);
+    }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
@@ -1,14 +1,16 @@
 package com.renzzle.backend.domain.puzzle.api;
 
-import com.renzzle.backend.domain.puzzle.api.request.AddPuzzleRequest;
+import com.renzzle.backend.domain.puzzle.api.request.AddCommunityPuzzleRequest;
 import com.renzzle.backend.domain.puzzle.api.response.AddPuzzleResponse;
 import com.renzzle.backend.domain.puzzle.service.CommunityService;
 import com.renzzle.backend.global.common.response.ApiResponse;
+import com.renzzle.backend.global.security.UserDetailsImpl;
 import com.renzzle.backend.global.util.ApiUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.ValidationException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,7 +27,10 @@ public class CommunityController {
     private final CommunityService communityService;
 
     @PostMapping("/puzzle")
-    public ApiResponse<AddPuzzleResponse> addPuzzle(@Valid @RequestBody AddPuzzleRequest request, BindingResult bindingResult) {
+    public ApiResponse<AddPuzzleResponse> addCommunityPuzzle(
+            @Valid @RequestBody AddCommunityPuzzleRequest request
+            , @AuthenticationPrincipal UserDetailsImpl user
+            , BindingResult bindingResult) {
         if(bindingResult.hasErrors()) {
             throw new ValidationException(getErrorMessages(bindingResult));
         }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
@@ -50,7 +50,9 @@ public class CommunityController {
             throw new ValidationException(getErrorMessages(bindingResult));
         }
 
-        return ApiUtils.success(null);
+        SortOption sortOption = SortOption.valueOf(sort);
+
+        return ApiUtils.success(communityService.getCommunityPuzzleList(id, size, sortOption));
     }
 
     @PostMapping("/puzzle")

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
@@ -1,0 +1,17 @@
+package com.renzzle.backend.domain.puzzle.api;
+
+import com.renzzle.backend.domain.puzzle.service.CommunityService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/community")
+@RequiredArgsConstructor
+@Tag(name = "Community Puzzle API", description = "Community Puzzle API")
+public class CommunityController {
+
+    private final CommunityService communityService;
+
+}

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
@@ -1,9 +1,13 @@
 package com.renzzle.backend.domain.puzzle.api;
 
 import com.renzzle.backend.domain.puzzle.api.request.AddCommunityPuzzleRequest;
+import com.renzzle.backend.domain.puzzle.api.request.CommunityPuzzleResultUpdateRequest;
 import com.renzzle.backend.domain.puzzle.api.response.AddPuzzleResponse;
+import com.renzzle.backend.domain.puzzle.domain.CommunityPuzzle;
 import com.renzzle.backend.domain.puzzle.service.CommunityService;
 import com.renzzle.backend.global.common.response.ApiResponse;
+import com.renzzle.backend.global.exception.CustomException;
+import com.renzzle.backend.global.exception.ErrorCode;
 import com.renzzle.backend.global.security.UserDetailsImpl;
 import com.renzzle.backend.global.util.ApiUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,13 +32,50 @@ public class CommunityController {
 
     @PostMapping("/puzzle")
     public ApiResponse<AddPuzzleResponse> addCommunityPuzzle(
-            @Valid @RequestBody AddCommunityPuzzleRequest request
-            , @AuthenticationPrincipal UserDetailsImpl user
-            , BindingResult bindingResult) {
+            @Valid @RequestBody AddCommunityPuzzleRequest request,
+            @AuthenticationPrincipal UserDetailsImpl user,
+            BindingResult bindingResult) {
         if(bindingResult.hasErrors()) {
             throw new ValidationException(getErrorMessages(bindingResult));
         }
-        return ApiUtils.success(null);
+
+        return ApiUtils.success(communityService.addCommunityPuzzle(request, user.getUser()));
+    }
+
+    @PostMapping("/solve")
+    public ApiResponse<Integer> solveCommunityPuzzle(
+            @Valid @RequestBody CommunityPuzzleResultUpdateRequest request,
+            @AuthenticationPrincipal UserDetailsImpl user,
+            BindingResult bindingResult) {
+        if(bindingResult.hasErrors()) {
+            throw new ValidationException(getErrorMessages(bindingResult));
+        }
+
+        CommunityPuzzle puzzle = communityService.findCommunityPuzzleById(request.puzzleId());
+        if(puzzle == null)
+            throw new CustomException(ErrorCode.CANNOT_FIND_COMMUNITY_PUZZLE);
+
+        int successCnt = communityService.solveCommunityPuzzle(puzzle, user.getUser());
+
+        return ApiUtils.success(successCnt);
+    }
+
+    @PostMapping("/fail")
+    public ApiResponse<Integer> failCommunityPuzzle(
+            @Valid @RequestBody CommunityPuzzleResultUpdateRequest request,
+            @AuthenticationPrincipal UserDetailsImpl user,
+            BindingResult bindingResult) {
+        if(bindingResult.hasErrors()) {
+            throw new ValidationException(getErrorMessages(bindingResult));
+        }
+
+        CommunityPuzzle puzzle = communityService.findCommunityPuzzleById(request.puzzleId());
+        if(puzzle == null)
+            throw new CustomException(ErrorCode.CANNOT_FIND_COMMUNITY_PUZZLE);
+
+        int failCnt = communityService.failCommunityPuzzle(puzzle, user.getUser());
+
+        return ApiUtils.success(failCnt);
     }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
@@ -10,19 +10,16 @@ import com.renzzle.backend.global.common.constant.SortOption;
 import com.renzzle.backend.global.common.response.ApiResponse;
 import com.renzzle.backend.global.security.UserDetailsImpl;
 import com.renzzle.backend.global.util.ApiUtils;
-import com.renzzle.backend.global.validation.ValidEnum;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.ValidationException;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
-import static com.renzzle.backend.global.util.BindingResultUtils.getErrorMessages;
+import static com.renzzle.backend.global.util.ErrorUtils.getErrorMessages;
 
 @RestController
 @RequestMapping("/api/community")

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
@@ -4,15 +4,13 @@ import com.renzzle.backend.domain.puzzle.api.request.AddCommunityPuzzleRequest;
 import com.renzzle.backend.domain.puzzle.api.request.CommunityPuzzleResultUpdateRequest;
 import com.renzzle.backend.domain.puzzle.api.response.AddPuzzleResponse;
 import com.renzzle.backend.domain.puzzle.api.response.GetCommunityPuzzleResponse;
-import com.renzzle.backend.domain.puzzle.domain.CommunityPuzzle;
 import com.renzzle.backend.domain.puzzle.service.CommunityService;
 import com.renzzle.backend.global.common.constant.SortOption;
 import com.renzzle.backend.global.common.response.ApiResponse;
-import com.renzzle.backend.global.exception.CustomException;
-import com.renzzle.backend.global.exception.ErrorCode;
 import com.renzzle.backend.global.security.UserDetailsImpl;
 import com.renzzle.backend.global.util.ApiUtils;
 import com.renzzle.backend.global.validation.ValidEnum;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.ValidationException;
@@ -33,6 +31,7 @@ public class CommunityController {
 
     private final CommunityService communityService;
 
+    @Operation(summary = "Get community puzzle data", description = "Return community puzzle list")
     @GetMapping("/puzzle")
     public ApiResponse<List<GetCommunityPuzzleResponse>> getCommunityPuzzle(
             @RequestParam(required = false) Long id,
@@ -55,6 +54,7 @@ public class CommunityController {
         return ApiUtils.success(communityService.getCommunityPuzzleList(id, size, sortOption));
     }
 
+    @Operation(summary = "Register new community puzzle", description = "Add new community puzzle")
     @PostMapping("/puzzle")
     public ApiResponse<AddPuzzleResponse> addCommunityPuzzle(
             @Valid @RequestBody AddCommunityPuzzleRequest request,
@@ -68,6 +68,7 @@ public class CommunityController {
         return ApiUtils.success(communityService.addCommunityPuzzle(request, user.getUser()));
     }
 
+    @Operation(summary = "Solve community puzzle", description = "Solve count increase & Apply correct rate")
     @PostMapping("/solve")
     public ApiResponse<Integer> solveCommunityPuzzle(
             @Valid @RequestBody CommunityPuzzleResultUpdateRequest request,
@@ -83,6 +84,7 @@ public class CommunityController {
         return ApiUtils.success(successCnt);
     }
 
+    @Operation(summary = "Fail community puzzle", description = "Fail count increase & Apply correct rate")
     @PostMapping("/fail")
     public ApiResponse<Integer> failCommunityPuzzle(
             @Valid @RequestBody CommunityPuzzleResultUpdateRequest request,

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/CommunityController.java
@@ -3,23 +3,26 @@ package com.renzzle.backend.domain.puzzle.api;
 import com.renzzle.backend.domain.puzzle.api.request.AddCommunityPuzzleRequest;
 import com.renzzle.backend.domain.puzzle.api.request.CommunityPuzzleResultUpdateRequest;
 import com.renzzle.backend.domain.puzzle.api.response.AddPuzzleResponse;
+import com.renzzle.backend.domain.puzzle.api.response.GetCommunityPuzzleResponse;
 import com.renzzle.backend.domain.puzzle.domain.CommunityPuzzle;
 import com.renzzle.backend.domain.puzzle.service.CommunityService;
+import com.renzzle.backend.global.common.constant.SortOption;
 import com.renzzle.backend.global.common.response.ApiResponse;
 import com.renzzle.backend.global.exception.CustomException;
 import com.renzzle.backend.global.exception.ErrorCode;
 import com.renzzle.backend.global.security.UserDetailsImpl;
 import com.renzzle.backend.global.util.ApiUtils;
+import com.renzzle.backend.global.validation.ValidEnum;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.ValidationException;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
 import static com.renzzle.backend.global.util.BindingResultUtils.getErrorMessages;
 
 @RestController
@@ -30,11 +33,32 @@ public class CommunityController {
 
     private final CommunityService communityService;
 
+    @GetMapping("/puzzle")
+    public ApiResponse<List<GetCommunityPuzzleResponse>> getCommunityPuzzle(
+            @RequestParam(required = false) Long id,
+
+            @Min(value = 1, message = "size는 최소 1이어야 합니다")
+            @Max(value = 100, message = "size는 최대 100이어야 합니다")
+            @RequestParam(defaultValue = "10") Integer size,
+
+            @ValidEnum(enumClass = SortOption.class, message = "잘못된 sort 형식입니다")
+            @RequestParam(defaultValue = "RECOMMEND") String sort,
+
+            BindingResult bindingResult
+    ) {
+        if(bindingResult.hasErrors()) {
+            throw new ValidationException(getErrorMessages(bindingResult));
+        }
+
+        return ApiUtils.success(null);
+    }
+
     @PostMapping("/puzzle")
     public ApiResponse<AddPuzzleResponse> addCommunityPuzzle(
             @Valid @RequestBody AddCommunityPuzzleRequest request,
             @AuthenticationPrincipal UserDetailsImpl user,
-            BindingResult bindingResult) {
+            BindingResult bindingResult
+    ) {
         if(bindingResult.hasErrors()) {
             throw new ValidationException(getErrorMessages(bindingResult));
         }
@@ -46,16 +70,13 @@ public class CommunityController {
     public ApiResponse<Integer> solveCommunityPuzzle(
             @Valid @RequestBody CommunityPuzzleResultUpdateRequest request,
             @AuthenticationPrincipal UserDetailsImpl user,
-            BindingResult bindingResult) {
+            BindingResult bindingResult
+    ) {
         if(bindingResult.hasErrors()) {
             throw new ValidationException(getErrorMessages(bindingResult));
         }
 
-        CommunityPuzzle puzzle = communityService.findCommunityPuzzleById(request.puzzleId());
-        if(puzzle == null)
-            throw new CustomException(ErrorCode.CANNOT_FIND_COMMUNITY_PUZZLE);
-
-        int successCnt = communityService.solveCommunityPuzzle(puzzle, user.getUser());
+        int successCnt = communityService.solveCommunityPuzzle(request.puzzleId(), user.getUser());
 
         return ApiUtils.success(successCnt);
     }
@@ -64,16 +85,13 @@ public class CommunityController {
     public ApiResponse<Integer> failCommunityPuzzle(
             @Valid @RequestBody CommunityPuzzleResultUpdateRequest request,
             @AuthenticationPrincipal UserDetailsImpl user,
-            BindingResult bindingResult) {
+            BindingResult bindingResult
+    ) {
         if(bindingResult.hasErrors()) {
             throw new ValidationException(getErrorMessages(bindingResult));
         }
 
-        CommunityPuzzle puzzle = communityService.findCommunityPuzzleById(request.puzzleId());
-        if(puzzle == null)
-            throw new CustomException(ErrorCode.CANNOT_FIND_COMMUNITY_PUZZLE);
-
-        int failCnt = communityService.failCommunityPuzzle(puzzle, user.getUser());
+        int failCnt = communityService.failCommunityPuzzle(request.puzzleId(), user.getUser());
 
         return ApiUtils.success(failCnt);
     }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/request/AddCommunityPuzzleRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/request/AddCommunityPuzzleRequest.java
@@ -2,26 +2,29 @@ package com.renzzle.backend.domain.puzzle.api.request;
 
 import com.renzzle.backend.domain.puzzle.domain.Difficulty;
 import com.renzzle.backend.domain.puzzle.domain.WinColor;
+import com.renzzle.backend.global.validation.ValidBoardString;
 import com.renzzle.backend.global.validation.ValidEnum;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record AddCommunityPuzzleRequest(
-        @NotBlank(message = "제목 정보가 없습니다")
+        @NotEmpty(message = "제목 정보가 없습니다")
         @Size(min = 1, max = 30, message = "제목은 1~30 자리의 문자열이어야 합니다")
         String title,
 
-        @NotBlank(message = "보드 정보가 없습니다")
+        @NotEmpty(message = "보드 정보가 없습니다")
+        @ValidBoardString
         String boardStatus,
 
-        @NotBlank(message = "깊이 정보가 없습니다")
-        int depth,
+        @NotNull(message = "깊이 정보가 없습니다")
+        Integer depth,
 
-        @NotBlank(message = "깊이 정보가 없습니다")
+        @NotEmpty(message = "깊이 정보가 없습니다")
         @ValidEnum(enumClass = Difficulty.DifficultyName.class, message = "잘못된 Difficulty 타입입니다")
         String difficulty,
 
-        @NotBlank(message = "깊이 정보가 없습니다")
+        @NotEmpty(message = "깊이 정보가 없습니다")
         @ValidEnum(enumClass = WinColor.WinColorName.class, message = "잘못된 WinColor 타입입니다")
         String winColor
 ) { }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/request/AddCommunityPuzzleRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/request/AddCommunityPuzzleRequest.java
@@ -6,7 +6,7 @@ import com.renzzle.backend.global.validation.ValidEnum;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-public record AddPuzzleRequest(
+public record AddCommunityPuzzleRequest(
         @NotBlank(message = "제목 정보가 없습니다")
         @Size(min = 1, max = 30, message = "제목은 1~30 자리의 문자열이어야 합니다")
         String title,

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/request/AddPuzzleRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/request/AddPuzzleRequest.java
@@ -1,0 +1,9 @@
+package com.renzzle.backend.domain.puzzle.api.request;
+
+public record AddPuzzleRequest(
+        String title,
+        String boardStatus,
+        int depth,
+        String difficulty,
+        String winColor
+) { }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/request/AddPuzzleRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/request/AddPuzzleRequest.java
@@ -1,9 +1,27 @@
 package com.renzzle.backend.domain.puzzle.api.request;
 
+import com.renzzle.backend.domain.puzzle.domain.Difficulty;
+import com.renzzle.backend.domain.puzzle.domain.WinColor;
+import com.renzzle.backend.global.validation.ValidEnum;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record AddPuzzleRequest(
+        @NotBlank(message = "제목 정보가 없습니다")
+        @Size(min = 1, max = 30, message = "제목은 1~30 자리의 문자열이어야 합니다")
         String title,
+
+        @NotBlank(message = "보드 정보가 없습니다")
         String boardStatus,
+
+        @NotBlank(message = "깊이 정보가 없습니다")
         int depth,
+
+        @NotBlank(message = "깊이 정보가 없습니다")
+        @ValidEnum(enumClass = Difficulty.DifficultyName.class, message = "잘못된 Difficulty 타입입니다")
         String difficulty,
+
+        @NotBlank(message = "깊이 정보가 없습니다")
+        @ValidEnum(enumClass = WinColor.WinColorName.class, message = "잘못된 WinColor 타입입니다")
         String winColor
 ) { }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/request/CommunityPuzzleResultUpdateRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/request/CommunityPuzzleResultUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.renzzle.backend.domain.puzzle.api.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CommunityPuzzleResultUpdateRequest(
+        @NotNull(message = "퍼즐 아이디 정보가 없습니다")
+        Long puzzleId
+) { }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/request/GetCommunityPuzzleRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/request/GetCommunityPuzzleRequest.java
@@ -1,0 +1,17 @@
+package com.renzzle.backend.domain.puzzle.api.request;
+
+import com.renzzle.backend.global.common.constant.SortOption;
+import com.renzzle.backend.global.validation.ValidEnum;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record GetCommunityPuzzleRequest(
+        Long id,
+
+        @Min(value = 1, message = "size는 최소 1이어야 합니다")
+        @Max(value = 100, message = "size는 최대 100이어야 합니다")
+        Integer size,
+
+        @ValidEnum(enumClass = SortOption.class, message = "잘못된 sort 형식입니다")
+        String sort
+) { }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/response/AddPuzzleResponse.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/response/AddPuzzleResponse.java
@@ -1,0 +1,9 @@
+package com.renzzle.backend.domain.puzzle.api.response;
+
+import lombok.Builder;
+
+@Builder
+public record AddPuzzleResponse(
+        long id,
+        String title
+) { }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/response/GetCommunityPuzzleResponse.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/response/GetCommunityPuzzleResponse.java
@@ -1,8 +1,7 @@
 package com.renzzle.backend.domain.puzzle.api.response;
 
 import lombok.Builder;
-
-import java.util.ArrayList;
+import java.util.List;
 
 @Builder
 public record GetCommunityPuzzleResponse(
@@ -17,5 +16,5 @@ public record GetCommunityPuzzleResponse(
         String difficulty,
         String winColor,
         int likeCount,
-        ArrayList<String> tag
+        List<String> tag
 ) { }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/response/GetCommunityPuzzleResponse.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/response/GetCommunityPuzzleResponse.java
@@ -1,0 +1,21 @@
+package com.renzzle.backend.domain.puzzle.api.response;
+
+import lombok.Builder;
+
+import java.util.ArrayList;
+
+@Builder
+public record GetCommunityPuzzleResponse(
+        long id,
+        String title,
+        String boardStatus,
+        long authorId,
+        String authorName,
+        int solvedCount,
+        double correctRate,
+        int depth,
+        String difficulty,
+        String winColor,
+        int likeCount,
+        ArrayList<String> tag
+) { }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/dao/CommunityPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/dao/CommunityPuzzleRepository.java
@@ -4,4 +4,5 @@ import com.renzzle.backend.domain.puzzle.domain.CommunityPuzzle;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommunityPuzzleRepository extends JpaRepository<CommunityPuzzle, Long> {
+
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/dao/CommunityPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/dao/CommunityPuzzleRepository.java
@@ -12,7 +12,7 @@ public interface CommunityPuzzleRepository extends JpaRepository<CommunityPuzzle
     @Query(value =
             "SELECT * FROM community_puzzle cp " +
             "WHERE (cp.created_at < :lastCreatedAt) OR (cp.created_at = :lastCreatedAt AND cp.id > :lastId) " +
-            "ORDER BY cp.created_at DESC, cp.id ASC" +
+            "ORDER BY cp.created_at DESC, cp.id ASC " +
             "LIMIT :size"
             , nativeQuery = true)
     List<CommunityPuzzle> findPuzzlesSortByCreatedAt(
@@ -24,7 +24,7 @@ public interface CommunityPuzzleRepository extends JpaRepository<CommunityPuzzle
     @Query(value =
             "SELECT * FROM community_puzzle cp " +
             "WHERE (cp.like_count < :lastLikeCnt) OR (cp.like_count = :lastLikeCnt AND cp.id > :lastId) " +
-            "ORDER BY cp.like_count DESC, cp.id ASC" +
+            "ORDER BY cp.like_count DESC, cp.id ASC " +
             "LIMIT :size"
             , nativeQuery = true)
     List<CommunityPuzzle> findPuzzlesSortByLike(

--- a/src/main/java/com/renzzle/backend/domain/puzzle/dao/CommunityPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/dao/CommunityPuzzleRepository.java
@@ -9,22 +9,24 @@ import java.util.List;
 
 public interface CommunityPuzzleRepository extends JpaRepository<CommunityPuzzle, Long> {
 
-    @Query(value = "SELECT * FROM community_puzzle cp " +
-            "WHERE (cp.created_at < :lastCreatedAt) OR " +
-            "(cp.created_at = :lastCreatedAt AND cp.id > :lastId) " +
+    @Query(value =
+            "SELECT * FROM community_puzzle cp " +
+            "WHERE (cp.created_at < :lastCreatedAt) OR (cp.created_at = :lastCreatedAt AND cp.id > :lastId) " +
             "ORDER BY cp.created_at DESC, cp.id ASC" +
-            "LIMIT :size", nativeQuery = true)
+            "LIMIT :size"
+            , nativeQuery = true)
     List<CommunityPuzzle> findPuzzlesSortByCreatedAt(
             @Param("lastCreatedAt") Instant lastCreatedAt,
             @Param("lastId") long lastId,
             @Param("size") int size
     );
 
-    @Query(value = "SELECT * FROM community_puzzle cp " +
-            "WHERE (cp.like_count < :lastLikeCnt) OR " +
-            "(cp.like_count = :lastLikeCnt AND cp.id > :lastId) " +
-            "ORDER BY cp.created_at DESC, cp.id ASC" +
-            "LIMIT :size", nativeQuery = true)
+    @Query(value =
+            "SELECT * FROM community_puzzle cp " +
+            "WHERE (cp.like_count < :lastLikeCnt) OR (cp.like_count = :lastLikeCnt AND cp.id > :lastId) " +
+            "ORDER BY cp.like_count DESC, cp.id ASC" +
+            "LIMIT :size"
+            , nativeQuery = true)
     List<CommunityPuzzle> findPuzzlesSortByLike(
             @Param("lastLikeCnt") int lastLikeCnt,
             @Param("lastId") long lastId,

--- a/src/main/java/com/renzzle/backend/domain/puzzle/dao/CommunityPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/dao/CommunityPuzzleRepository.java
@@ -1,0 +1,7 @@
+package com.renzzle.backend.domain.puzzle.dao;
+
+import com.renzzle.backend.domain.puzzle.domain.CommunityPuzzle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommunityPuzzleRepository extends JpaRepository<CommunityPuzzle, Long> {
+}

--- a/src/main/java/com/renzzle/backend/domain/puzzle/dao/CommunityPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/dao/CommunityPuzzleRepository.java
@@ -2,7 +2,33 @@ package com.renzzle.backend.domain.puzzle.dao;
 
 import com.renzzle.backend.domain.puzzle.domain.CommunityPuzzle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.time.Instant;
+import java.util.List;
 
 public interface CommunityPuzzleRepository extends JpaRepository<CommunityPuzzle, Long> {
+
+    @Query(value = "SELECT * FROM community_puzzle cp " +
+            "WHERE (cp.created_at < :lastCreatedAt) OR " +
+            "(cp.created_at = :lastCreatedAt AND cp.id > :lastId) " +
+            "ORDER BY cp.created_at DESC, cp.id ASC" +
+            "LIMIT :size", nativeQuery = true)
+    List<CommunityPuzzle> findPuzzlesSortByCreatedAt(
+            @Param("lastCreatedAt") Instant lastCreatedAt,
+            @Param("lastId") long lastId,
+            @Param("size") int size
+    );
+
+    @Query(value = "SELECT * FROM community_puzzle cp " +
+            "WHERE (cp.like_count < :lastLikeCnt) OR " +
+            "(cp.like_count = :lastLikeCnt AND cp.id > :lastId) " +
+            "ORDER BY cp.created_at DESC, cp.id ASC" +
+            "LIMIT :size", nativeQuery = true)
+    List<CommunityPuzzle> findPuzzlesSortByLike(
+            @Param("lastLikeCnt") int lastLikeCnt,
+            @Param("lastId") long lastId,
+            @Param("size") int size
+    );
 
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/dao/UserCommunityPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/dao/UserCommunityPuzzleRepository.java
@@ -2,6 +2,13 @@ package com.renzzle.backend.domain.puzzle.dao;
 
 import com.renzzle.backend.domain.puzzle.domain.UserCommunityPuzzle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.Optional;
 
 public interface UserCommunityPuzzleRepository extends JpaRepository<UserCommunityPuzzle, Long> {
+
+    @Query("SELECT u FROM UserCommunityPuzzle u WHERE u.user.id = :userId AND u.puzzle.id = :puzzleId")
+    Optional<UserCommunityPuzzle> findUserPuzzleInfo(@Param("userId") Long userId, @Param("puzzleId") Long puzzleId);
+
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/dao/UserCommunityPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/dao/UserCommunityPuzzleRepository.java
@@ -1,0 +1,7 @@
+package com.renzzle.backend.domain.puzzle.dao;
+
+import com.renzzle.backend.domain.puzzle.domain.UserCommunityPuzzle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserCommunityPuzzleRepository extends JpaRepository<UserCommunityPuzzle, Long> {
+}

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
@@ -40,6 +40,18 @@ public class CommunityPuzzle {
     @Column(name = "depth", nullable = false)
     private int depth;
 
+    @Column(name = "like_count", nullable = false)
+    @Builder.Default
+    private int likeCount = 0;
+
+    @Column(name = "solved_count", nullable = false)
+    @Builder.Default
+    private int solvedCount = 0;
+
+    @Column(name = "failed_count", nullable = false)
+    @Builder.Default
+    private int failedCount = 0;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false, nullable = false)
     private Instant createdAt;
@@ -78,6 +90,22 @@ public class CommunityPuzzle {
     public void onPreRemove() {
         this.status.setStatus(Status.StatusName.DELETED);
         this.deletedAt = Instant.now();
+    }
+
+    public int addSolve() {
+        this.solvedCount++;
+        return this.solvedCount;
+    }
+
+    public int addFail() {
+        this.failedCount++;
+        return this.failedCount;
+    }
+
+    public int changeLike(boolean isIncrease) {
+        if(isIncrease) this.likeCount++;
+        else this.likeCount--;
+        return this.likeCount;
     }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
@@ -1,0 +1,56 @@
+package com.renzzle.backend.domain.puzzle.domain;
+
+import com.renzzle.backend.domain.user.domain.UserEntity;
+import com.renzzle.backend.global.common.domain.Status;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.time.Instant;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Table(name = "community_puzzle")
+public class CommunityPuzzle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 31)
+    private String title;
+
+    @Column(nullable = false, length = 1023)
+    private String boardStatus;
+
+    @Column(nullable = false)
+    private int depth;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @ManyToOne
+    @JoinColumn(name = "status", nullable = false)
+    private Status status;
+
+    @ManyToOne
+    @JoinColumn(name = "author_id", nullable = false)
+    private UserEntity user;
+
+    @ManyToOne
+    @JoinColumn(name = "difficulty", nullable = false)
+    private Difficulty difficulty;
+
+    @ManyToOne
+    @JoinColumn(name = "win_color", nullable = false)
+    private WinColor winColor;
+
+}

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
@@ -64,7 +64,7 @@ public class CommunityPuzzle {
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
-    @Column(name = "deleted_at")
+    @Column(name = "deleted_at", nullable = false)
     private Instant deletedAt;
 
     @ManyToOne
@@ -87,6 +87,9 @@ public class CommunityPuzzle {
     public void prePersist() {
         if(status == null) {
             this.status = Status.getDefaultStatus();
+        }
+        if(deletedAt == null) {
+            this.deletedAt = Instant.EPOCH;
         }
     }
 

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
@@ -3,10 +3,11 @@ package com.renzzle.backend.domain.puzzle.domain;
 import com.renzzle.backend.domain.user.domain.UserEntity;
 import com.renzzle.backend.global.common.domain.Status;
 import jakarta.persistence.*;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.*;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.SQLRestriction;
-import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.*;
+
 import java.time.Instant;
 import static com.renzzle.backend.global.common.constant.TimeConstant.CONST_FUTURE_INSTANT;
 import static com.renzzle.backend.global.common.domain.Status.STATUS_IS_NOT_DELETED;
@@ -74,6 +75,7 @@ public class CommunityPuzzle {
 
     @ManyToOne
     @JoinColumn(name = "author_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private UserEntity user;
 
     @ManyToOne

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
@@ -8,6 +8,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.annotations.UpdateTimestamp;
 import java.time.Instant;
+import static com.renzzle.backend.global.common.constant.TimeConstant.CONST_FUTURE_INSTANT;
 import static com.renzzle.backend.global.common.domain.Status.STATUS_IS_NOT_DELETED;
 
 @Entity
@@ -38,7 +39,7 @@ public class CommunityPuzzle {
     @Column(name = "board_status", nullable = false, length = 1023)
     private String boardStatus;
 
-    @Column(name = "board_key", nullable = false, length = 1023)
+    @Column(name = "board_key", nullable = false)
     private String boardKey;
 
     @Column(name = "depth", nullable = false)
@@ -89,7 +90,7 @@ public class CommunityPuzzle {
             this.status = Status.getDefaultStatus();
         }
         if(deletedAt == null) {
-            this.deletedAt = Instant.EPOCH;
+            this.deletedAt = CONST_FUTURE_INSTANT;
         }
     }
 

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
@@ -98,7 +98,7 @@ public class CommunityPuzzle {
 
     @PreRemove
     public void onPreRemove() {
-        this.status.setStatus(Status.StatusName.DELETED);
+        this.status = Status.getStatus(Status.StatusName.DELETED);
         this.deletedAt = Instant.now();
     }
 

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
@@ -19,6 +19,10 @@ import static com.renzzle.backend.global.common.domain.Status.STATUS_IS_NOT_DELE
         name = "community_puzzle",
         uniqueConstraints = {
                 @UniqueConstraint(columnNames = {"board_key", "status", "deleted_at"})
+        },
+        indexes = {
+                @Index(columnList = "created_at"),
+                @Index(columnList = "like_count")
         }
 )
 @SQLRestriction(value = STATUS_IS_NOT_DELETED)

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
@@ -35,7 +35,7 @@ public class CommunityPuzzle {
     @Column(name = "title", nullable = false, length = 31)
     private String title;
 
-    @Column(name = "board_status",nullable = false, length = 1023)
+    @Column(name = "board_status", nullable = false, length = 1023)
     private String boardStatus;
 
     @Column(name = "board_key", nullable = false, length = 1023)

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
@@ -53,4 +53,11 @@ public class CommunityPuzzle {
     @JoinColumn(name = "win_color", nullable = false)
     private WinColor winColor;
 
+    @PrePersist
+    public void prePersist() {
+        if(status == null) {
+            this.status = Status.getDefaultStatus();
+        }
+    }
+
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/CommunityPuzzle.java
@@ -26,6 +26,9 @@ public class CommunityPuzzle {
     @Column(nullable = false, length = 1023)
     private String boardStatus;
 
+    @Column(nullable = false, unique = true, length = 1023)
+    private String boardKey;
+
     @Column(nullable = false)
     private int depth;
 

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/Difficulty.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/Difficulty.java
@@ -43,8 +43,4 @@ public class Difficulty {
         this.name = difficultyName;
     }
 
-    public void setDifficulty(Difficulty.DifficultyName difficultyName) {
-        this.name = difficultyName.name();
-    }
-
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/Difficulty.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/Difficulty.java
@@ -7,11 +7,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.util.Arrays;
 
 @Entity
 @Table(name = "difficulty")
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Difficulty {
 

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/Difficulty.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/Difficulty.java
@@ -1,0 +1,44 @@
+package com.renzzle.backend.domain.puzzle.domain;
+
+import com.renzzle.backend.global.exception.CustomException;
+import com.renzzle.backend.global.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import java.util.Arrays;
+
+@Entity
+@Table(name = "difficulty")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Difficulty {
+
+    @Id
+    @Column(length = 31)
+    private String name;
+
+    private Difficulty(String name) {
+        this.name = name;
+    }
+
+    public enum DifficultyName {
+        HIGH, MIDDLE, LOW
+    }
+
+    public void setDifficulty(String difficultyName) {
+        Difficulty.DifficultyName[] difficultyNames = Difficulty.DifficultyName.values();
+        boolean isValid = Arrays.stream(difficultyNames)
+                .anyMatch(difficulty -> difficulty.name().equals(difficultyName));
+        if(!isValid)
+            throw new CustomException(ErrorCode.VALIDATION_ERROR);
+
+        this.name = difficultyName;
+    }
+
+    public void setDifficulty(Difficulty.DifficultyName difficultyName) {
+        this.name = difficultyName.name();
+    }
+
+}

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/Difficulty.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/Difficulty.java
@@ -27,12 +27,18 @@ public class Difficulty {
         HIGH, MIDDLE, LOW
     }
 
+    public static Difficulty getDifficulty(String difficultyName) {
+        Difficulty difficulty = new Difficulty();
+        difficulty.setDifficulty(difficultyName);
+        return difficulty;
+    }
+
     public void setDifficulty(String difficultyName) {
         Difficulty.DifficultyName[] difficultyNames = Difficulty.DifficultyName.values();
         boolean isValid = Arrays.stream(difficultyNames)
                 .anyMatch(difficulty -> difficulty.name().equals(difficultyName));
         if(!isValid)
-            throw new CustomException(ErrorCode.VALIDATION_ERROR);
+            throw new IllegalArgumentException("Invalid difficulty name: " + difficultyName);
 
         this.name = difficultyName;
     }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/LessonPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/LessonPuzzle.java
@@ -1,0 +1,56 @@
+package com.renzzle.backend.domain.puzzle.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.time.Instant;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Table(name = "lesson_puzzle")
+public class LessonPuzzle {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Long id;
+
+        @Column(name = "chapter", nullable = false)
+        private int chapter;
+
+        @Column(name = "lesson_index", unique = true, nullable = false)
+        private int lessonIndex;
+
+        @Column(name = "title", nullable = false, length = 31)
+        private String title;
+
+        @Column(name = "board_status", nullable = false, length = 1023)
+        private String boardStatus;
+
+        @Column(name = "board_key", unique = true, nullable = false, length = 1023)
+        private String boardKey;
+
+        @Column(name = "depth", nullable = false)
+        private int depth;
+
+        @Column(name = "description")
+        private String description;
+
+        @UpdateTimestamp
+        @Column(name = "updated_at", nullable = false)
+        private Instant updatedAt;
+
+        @Column(name = "deleted_at")
+        private Instant deletedAt;
+
+        @ManyToOne
+        @JoinColumn(name = "difficulty", nullable = false)
+        private Difficulty difficulty;
+
+        @ManyToOne
+        @JoinColumn(name = "win_color", nullable = false)
+        private WinColor winColor;
+
+}

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/LessonPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/LessonPuzzle.java
@@ -29,7 +29,7 @@ public class LessonPuzzle {
         @Column(name = "board_status", nullable = false, length = 1023)
         private String boardStatus;
 
-        @Column(name = "board_key", unique = true, nullable = false, length = 1023)
+        @Column(name = "board_key", unique = true, nullable = false)
         private String boardKey;
 
         @Column(name = "depth", nullable = false)

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/SolvedLessonPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/SolvedLessonPuzzle.java
@@ -4,6 +4,9 @@ import com.renzzle.backend.domain.user.domain.UserEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import java.time.Instant;
 
 @Entity
@@ -20,12 +23,12 @@ public class SolvedLessonPuzzle {
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
-    @Cascade(org.hibernate.annotations.CascadeType.REMOVE)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private UserEntity user;
 
     @ManyToOne
     @JoinColumn(name = "lesson_id", nullable = false)
-    @Cascade(org.hibernate.annotations.CascadeType.REMOVE)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private LessonPuzzle puzzle;
 
     @Column(name = "solved_at", nullable = false)

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/SolvedLessonPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/SolvedLessonPuzzle.java
@@ -1,0 +1,34 @@
+package com.renzzle.backend.domain.puzzle.domain;
+
+import com.renzzle.backend.domain.user.domain.UserEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Cascade;
+import java.time.Instant;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Table(name = "solved_lesson_puzzle")
+public class SolvedLessonPuzzle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    @Cascade(org.hibernate.annotations.CascadeType.REMOVE)
+    private UserEntity user;
+
+    @ManyToOne
+    @JoinColumn(name = "lesson_id", nullable = false)
+    @Cascade(org.hibernate.annotations.CascadeType.REMOVE)
+    private LessonPuzzle puzzle;
+
+    @Column(name = "solved_at", nullable = false)
+    private Instant solvedAt;
+
+}

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/Tag.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/Tag.java
@@ -1,0 +1,7 @@
+package com.renzzle.backend.domain.puzzle.domain;
+
+public enum Tag {
+
+    SOLVED
+
+}

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/UserCommunityPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/UserCommunityPuzzle.java
@@ -2,7 +2,6 @@ package com.renzzle.backend.domain.puzzle.domain;
 
 import com.renzzle.backend.domain.user.domain.UserEntity;
 import jakarta.persistence.*;
-import jakarta.validation.groups.Default;
 import lombok.*;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
@@ -44,5 +43,22 @@ public class UserCommunityPuzzle {
     @Column(name = "is_liked", nullable = false)
     @Builder.Default
     private boolean like = false;
+
+    public int addSolve() {
+        this.solvedCount++;
+        lastTriedAt = Instant.now();
+        return this.solvedCount;
+    }
+
+    public int addFail() {
+        this.failedCount++;
+        lastTriedAt = Instant.now();
+        return this.failedCount;
+    }
+
+    public boolean toggleLike() {
+        this.like = !this.like;
+        return this.like;
+    }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/UserCommunityPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/UserCommunityPuzzle.java
@@ -1,0 +1,44 @@
+package com.renzzle.backend.domain.puzzle.domain;
+
+import com.renzzle.backend.domain.user.domain.UserEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
+import java.time.Instant;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Table(name = "user_community_puzzle")
+public class UserCommunityPuzzle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Cascade(CascadeType.REMOVE)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    @ManyToOne
+    @JoinColumn(name = "community_id", nullable = false)
+    @Cascade(CascadeType.REMOVE)
+    private CommunityPuzzle puzzle;
+
+    @Column(name = "last_tried_at", nullable = false)
+    private Instant lastTriedAt;
+
+    @Column(name = "solved_count", nullable = false)
+    private int solvedCount = 0;
+
+    @Column(name = "failed_count", nullable = false)
+    private int failedCount = 0;
+
+    @Column(name = "like", nullable = false)
+    private boolean like = false;
+
+}

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/UserCommunityPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/UserCommunityPuzzle.java
@@ -2,6 +2,7 @@ package com.renzzle.backend.domain.puzzle.domain;
 
 import com.renzzle.backend.domain.user.domain.UserEntity;
 import jakarta.persistence.*;
+import jakarta.validation.groups.Default;
 import lombok.*;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
@@ -33,12 +34,15 @@ public class UserCommunityPuzzle {
     private Instant lastTriedAt;
 
     @Column(name = "solved_count", nullable = false)
+    @Builder.Default
     private int solvedCount = 0;
 
     @Column(name = "failed_count", nullable = false)
+    @Builder.Default
     private int failedCount = 0;
 
-    @Column(name = "like", nullable = false)
+    @Column(name = "is_liked", nullable = false)
+    @Builder.Default
     private boolean like = false;
 
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/UserCommunityPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/UserCommunityPuzzle.java
@@ -5,6 +5,9 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import java.time.Instant;
 
 @Entity
@@ -17,16 +20,16 @@ public class UserCommunityPuzzle {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Cascade(CascadeType.REMOVE)
     private Long id;
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private UserEntity user;
 
     @ManyToOne
     @JoinColumn(name = "community_id", nullable = false)
-    @Cascade(CascadeType.REMOVE)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private CommunityPuzzle puzzle;
 
     @Column(name = "last_tried_at", nullable = false)

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/WinColor.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/WinColor.java
@@ -43,8 +43,4 @@ public class WinColor {
         this.name = winColorName;
     }
 
-    public void setWinColor(WinColor.WinColorName winColorName) {
-        this.name = winColorName.name();
-    }
-
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/WinColor.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/WinColor.java
@@ -27,12 +27,18 @@ public class WinColor {
         BLACK, WHITE
     }
 
+    public static WinColor getWinColor(String winColorName) {
+        WinColor winColor = new WinColor();
+        winColor.setWinColor(winColorName);
+        return winColor;
+    }
+
     public void setWinColor(String winColorName) {
         WinColor.WinColorName[] winColorNames = WinColor.WinColorName.values();
         boolean isValid = Arrays.stream(winColorNames)
                 .anyMatch(winColor -> winColor.name().equals(winColorName));
         if(!isValid)
-            throw new CustomException(ErrorCode.VALIDATION_ERROR);
+            throw new IllegalArgumentException("Invalid win color name: " + winColorName);
 
         this.name = winColorName;
     }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/WinColor.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/WinColor.java
@@ -1,0 +1,44 @@
+package com.renzzle.backend.domain.puzzle.domain;
+
+import com.renzzle.backend.global.exception.CustomException;
+import com.renzzle.backend.global.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import java.util.Arrays;
+
+@Entity
+@Table(name = "win_color")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WinColor {
+
+    @Id
+    @Column(length = 31)
+    private String name;
+
+    private WinColor(String name) {
+        this.name = name;
+    }
+
+    public enum WinColorName {
+        BLACK, WHITE
+    }
+
+    public void setWinColor(String winColorName) {
+        WinColor.WinColorName[] winColorNames = WinColor.WinColorName.values();
+        boolean isValid = Arrays.stream(winColorNames)
+                .anyMatch(winColor -> winColor.name().equals(winColorName));
+        if(!isValid)
+            throw new CustomException(ErrorCode.VALIDATION_ERROR);
+
+        this.name = winColorName;
+    }
+
+    public void setWinColor(WinColor.WinColorName winColorName) {
+        this.name = winColorName.name();
+    }
+
+}

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/WinColor.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/WinColor.java
@@ -7,11 +7,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.util.Arrays;
 
 @Entity
 @Table(name = "win_color")
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WinColor {
 

--- a/src/main/java/com/renzzle/backend/domain/puzzle/service/CommunityService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/service/CommunityService.java
@@ -66,9 +66,10 @@ public class CommunityService {
         Optional<UserCommunityPuzzle> findResult = userCommunityPuzzleRepository.findUserPuzzleInfo(user.getId(), puzzle.getId());
         UserCommunityPuzzle userPuzzleInfo = findResult.orElseGet(() -> userCommunityPuzzleRepository.save(
                 UserCommunityPuzzle.builder()
-                .user(user)
-                .puzzle(puzzle)
-                .build()));
+                        .user(user)
+                        .puzzle(puzzle)
+                        .lastTriedAt(Instant.now())
+                        .build()));
 
         puzzle.addSolve();
 
@@ -86,6 +87,7 @@ public class CommunityService {
                 UserCommunityPuzzle.builder()
                         .user(user)
                         .puzzle(puzzle)
+                        .lastTriedAt(Instant.now())
                         .build()));
 
         puzzle.addFail();

--- a/src/main/java/com/renzzle/backend/domain/puzzle/service/CommunityService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/service/CommunityService.java
@@ -1,7 +1,13 @@
 package com.renzzle.backend.domain.puzzle.service;
 
+import com.renzzle.backend.domain.puzzle.api.request.AddCommunityPuzzleRequest;
+import com.renzzle.backend.domain.puzzle.api.response.AddPuzzleResponse;
 import com.renzzle.backend.domain.puzzle.dao.CommunityPuzzleRepository;
 import com.renzzle.backend.domain.puzzle.dao.UserCommunityPuzzleRepository;
+import com.renzzle.backend.domain.puzzle.domain.CommunityPuzzle;
+import com.renzzle.backend.domain.puzzle.domain.Difficulty;
+import com.renzzle.backend.domain.puzzle.domain.WinColor;
+import com.renzzle.backend.domain.user.domain.UserEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,5 +17,23 @@ public class CommunityService {
 
     private final CommunityPuzzleRepository communityPuzzleRepository;
     private final UserCommunityPuzzleRepository userCommunityPuzzleRepository;
+
+    public AddPuzzleResponse addCommunityPuzzle(AddCommunityPuzzleRequest request, UserEntity user) {
+        CommunityPuzzle puzzle = CommunityPuzzle.builder()
+                .title(request.title())
+                .boardStatus(request.boardStatus())
+                .depth(request.depth())
+                .user(user)
+                .difficulty(Difficulty.getDifficulty(request.difficulty()))
+                .winColor(WinColor.getWinColor(request.winColor()))
+                .build();
+
+        CommunityPuzzle result = communityPuzzleRepository.save(puzzle);
+
+        return AddPuzzleResponse.builder()
+                .id(result.getId())
+                .title(result.getTitle())
+                .build();
+    }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/service/CommunityService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/service/CommunityService.java
@@ -9,6 +9,8 @@ import com.renzzle.backend.domain.puzzle.domain.Difficulty;
 import com.renzzle.backend.domain.puzzle.domain.UserCommunityPuzzle;
 import com.renzzle.backend.domain.puzzle.domain.WinColor;
 import com.renzzle.backend.domain.user.domain.UserEntity;
+import com.renzzle.backend.global.exception.CustomException;
+import com.renzzle.backend.global.exception.ErrorCode;
 import com.renzzle.backend.global.util.BoardUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -52,7 +54,11 @@ public class CommunityService {
     }
 
     @Transactional
-    public int solveCommunityPuzzle(CommunityPuzzle puzzle, UserEntity user) {
+    public int solveCommunityPuzzle(Long puzzleId, UserEntity user) {
+        CommunityPuzzle puzzle = findCommunityPuzzleById(puzzleId);
+        if(puzzle == null)
+            throw new CustomException(ErrorCode.CANNOT_FIND_COMMUNITY_PUZZLE);
+
         Optional<UserCommunityPuzzle> findResult = userCommunityPuzzleRepository.findUserPuzzleInfo(user.getId(), puzzle.getId());
         UserCommunityPuzzle userPuzzleInfo = findResult.orElseGet(() -> userCommunityPuzzleRepository.save(
                 UserCommunityPuzzle.builder()
@@ -60,17 +66,25 @@ public class CommunityService {
                 .puzzle(puzzle)
                 .build()));
 
+        puzzle.addSolve();
+
         return userPuzzleInfo.addSolve();
     }
 
     @Transactional
-    public int failCommunityPuzzle(CommunityPuzzle puzzle, UserEntity user) {
+    public int failCommunityPuzzle(Long puzzleId, UserEntity user) {
+        CommunityPuzzle puzzle = findCommunityPuzzleById(puzzleId);
+        if(puzzle == null)
+            throw new CustomException(ErrorCode.CANNOT_FIND_COMMUNITY_PUZZLE);
+
         Optional<UserCommunityPuzzle> findResult = userCommunityPuzzleRepository.findUserPuzzleInfo(user.getId(), puzzle.getId());
         UserCommunityPuzzle userPuzzleInfo = findResult.orElseGet(() -> userCommunityPuzzleRepository.save(
                 UserCommunityPuzzle.builder()
                         .user(user)
                         .puzzle(puzzle)
                         .build()));
+
+        puzzle.addFail();
 
         return userPuzzleInfo.addFail();
     }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/service/CommunityService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/service/CommunityService.java
@@ -21,13 +21,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static com.renzzle.backend.global.common.constant.TimeConstant.CONST_FUTURE_INSTANT;
+
 @Service
 @RequiredArgsConstructor
 public class CommunityService {
 
     private final CommunityPuzzleRepository communityPuzzleRepository;
     private final UserCommunityPuzzleRepository userCommunityPuzzleRepository;
-    private final UserRepository userRepository;
 
     @Transactional
     public AddPuzzleResponse addCommunityPuzzle(AddCommunityPuzzleRequest request, UserEntity user) {
@@ -145,7 +146,7 @@ public class CommunityService {
 
         if(id == null) {
             lastId = -1L;
-            lastCreatedAt = Instant.parse("9999-01-01T00:00:00Z");
+            lastCreatedAt = CONST_FUTURE_INSTANT;
         } else {
             lastId = id;
             CommunityPuzzle puzzle = communityPuzzleRepository.findById(id)
@@ -181,7 +182,7 @@ public class CommunityService {
 
         if(id == null) {
             lastId = -1L;
-            lastCreatedAt = Instant.MAX;
+            lastCreatedAt = CONST_FUTURE_INSTANT;
         } else {
             lastId = id;
             CommunityPuzzle puzzle = communityPuzzleRepository.findById(id)

--- a/src/main/java/com/renzzle/backend/domain/puzzle/service/CommunityService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/service/CommunityService.java
@@ -8,6 +8,7 @@ import com.renzzle.backend.domain.puzzle.domain.CommunityPuzzle;
 import com.renzzle.backend.domain.puzzle.domain.Difficulty;
 import com.renzzle.backend.domain.puzzle.domain.WinColor;
 import com.renzzle.backend.domain.user.domain.UserEntity;
+import com.renzzle.backend.global.util.BoardUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +20,8 @@ public class CommunityService {
     private final UserCommunityPuzzleRepository userCommunityPuzzleRepository;
 
     public AddPuzzleResponse addCommunityPuzzle(AddCommunityPuzzleRequest request, UserEntity user) {
+        String boardKey = BoardUtils.makeBoardKey(request.boardStatus());
+
         CommunityPuzzle puzzle = CommunityPuzzle.builder()
                 .title(request.title())
                 .boardStatus(request.boardStatus())

--- a/src/main/java/com/renzzle/backend/domain/puzzle/service/CommunityService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/service/CommunityService.java
@@ -6,21 +6,20 @@ import com.renzzle.backend.domain.puzzle.api.response.GetCommunityPuzzleResponse
 import com.renzzle.backend.domain.puzzle.dao.CommunityPuzzleRepository;
 import com.renzzle.backend.domain.puzzle.dao.UserCommunityPuzzleRepository;
 import com.renzzle.backend.domain.puzzle.domain.*;
-import com.renzzle.backend.domain.user.dao.UserRepository;
 import com.renzzle.backend.domain.user.domain.UserEntity;
 import com.renzzle.backend.global.common.constant.SortOption;
+import com.renzzle.backend.global.common.domain.Status;
 import com.renzzle.backend.global.exception.CustomException;
 import com.renzzle.backend.global.exception.ErrorCode;
 import com.renzzle.backend.global.util.BoardUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
+import static com.renzzle.backend.global.common.constant.StringConstant.DELETED_USER;
 import static com.renzzle.backend.global.common.constant.TimeConstant.CONST_FUTURE_INSTANT;
 
 @Service
@@ -116,6 +115,8 @@ public class CommunityService {
         for(CommunityPuzzle puzzle : puzzleList) {
             double correctRate = (double) puzzle.getSolvedCount() / (puzzle.getSolvedCount() + puzzle.getFailedCount()) * 100;
             List<String> tags = getTags(puzzle);
+            String authorName = (puzzle.getUser().getStatus() != Status.getStatus(Status.StatusName.DELETED)) ?
+                    puzzle.getUser().getNickname() : DELETED_USER;
 
             response.add(
                     GetCommunityPuzzleResponse.builder()
@@ -123,7 +124,7 @@ public class CommunityService {
                             .title(puzzle.getTitle())
                             .boardStatus(puzzle.getBoardStatus())
                             .authorId(puzzle.getUser().getId())
-                            .authorName(puzzle.getUser().getNickname())
+                            .authorName(authorName)
                             .solvedCount(puzzle.getSolvedCount())
                             .correctRate(correctRate)
                             .depth(puzzle.getDepth())

--- a/src/main/java/com/renzzle/backend/domain/puzzle/service/CommunityService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/service/CommunityService.java
@@ -1,0 +1,15 @@
+package com.renzzle.backend.domain.puzzle.service;
+
+import com.renzzle.backend.domain.puzzle.dao.CommunityPuzzleRepository;
+import com.renzzle.backend.domain.puzzle.dao.UserCommunityPuzzleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommunityService {
+
+    private final CommunityPuzzleRepository communityPuzzleRepository;
+    private final UserCommunityPuzzleRepository userCommunityPuzzleRepository;
+
+}

--- a/src/main/java/com/renzzle/backend/domain/puzzle/service/CommunityService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/service/CommunityService.java
@@ -143,7 +143,7 @@ public class CommunityService {
 
         if(id == null) {
             lastId = -1L;
-            lastCreatedAt = Instant.MAX;
+            lastCreatedAt = Instant.parse("9999-01-01T00:00:00Z");
         } else {
             lastId = id;
             CommunityPuzzle puzzle = communityPuzzleRepository.findById(id)

--- a/src/main/java/com/renzzle/backend/domain/test/api/TestController.java
+++ b/src/main/java/com/renzzle/backend/domain/test/api/TestController.java
@@ -16,7 +16,7 @@ import jakarta.validation.ValidationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
-import static com.renzzle.backend.global.util.BindingResultUtils.getErrorMessages;
+import static com.renzzle.backend.global.util.ErrorUtils.getErrorMessages;
 
 @RestController
 @RequestMapping("/api/test")

--- a/src/main/java/com/renzzle/backend/domain/test/api/request/SaveEntityRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/test/api/request/SaveEntityRequest.java
@@ -1,8 +1,10 @@
 package com.renzzle.backend.domain.test.api.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record SaveEntityRequest(
+        @NotBlank(message = "이름 정보가 없습니다")
         @Size(max = 6, message = "이름은 6자 이하만 가능합니다")
         String name
 ) { }

--- a/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
@@ -6,11 +6,8 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.annotations.UpdateTimestamp;
-
 import java.time.Instant;
-
-import static com.renzzle.backend.global.common.domain.Status.DELETED_NICKNAME_SUFFIX;
-import static com.renzzle.backend.global.common.domain.Status.STATUS_RESTRICTION;
+import static com.renzzle.backend.global.common.domain.Status.STATUS_IS_NOT_DELETED;
 
 @Entity
 @Getter
@@ -20,23 +17,24 @@ import static com.renzzle.backend.global.common.domain.Status.STATUS_RESTRICTION
 @Table(
         name = "user",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"email", "status"}),
+                @UniqueConstraint(columnNames = {"email", "status", "deleted_at"}),
+                @UniqueConstraint(columnNames = {"nickname", "status", "deleted_at"}),
         }
 )
-@SQLRestriction(value = STATUS_RESTRICTION)
+@SQLRestriction(value = STATUS_IS_NOT_DELETED)
 public class UserEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(name = "email", nullable = false)
     private String email;
 
-    @Column(nullable = false)
+    @Column(name = "password", nullable = false)
     private String password;
 
-    @Column(nullable = false, unique = true, length = 31)
+    @Column(name = "nickname", nullable = false, unique = true, length = 31)
     private String nickname;
 
     @CreationTimestamp
@@ -46,6 +44,9 @@ public class UserEntity {
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
+
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
 
     @ManyToOne
     @JoinColumn(name = "status", nullable = false)
@@ -75,7 +76,7 @@ public class UserEntity {
     @PreRemove
     public void onPreRemove() {
         this.status.setStatus(Status.StatusName.DELETED);
-        this.nickname += DELETED_NICKNAME_SUFFIX;
+        this.deletedAt = Instant.now();
     }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
@@ -79,7 +79,7 @@ public class UserEntity {
 
     @PreRemove
     public void onPreRemove() {
-        this.status.setStatus(Status.StatusName.DELETED);
+        this.status = Status.getStatus(Status.StatusName.DELETED);
         this.deletedAt = Instant.now();
     }
 

--- a/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
@@ -45,7 +45,7 @@ public class UserEntity {
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
-    @Column(name = "deleted_at")
+    @Column(name = "deleted_at", nullable = false)
     private Instant deletedAt;
 
     @ManyToOne
@@ -64,6 +64,9 @@ public class UserEntity {
     public void onPrePersist() {
         if(status == null) {
             this.status = Status.getDefaultStatus();
+        }
+        if(deletedAt == null) {
+            this.deletedAt = Instant.EPOCH;
         }
         if(color == null) {
             this.color = Color.getRandomColor();

--- a/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
@@ -35,7 +35,7 @@ public class UserEntity {
     @Column(name = "password", nullable = false)
     private String password;
 
-    @Column(name = "nickname", nullable = false, unique = true, length = 31)
+    @Column(name = "nickname", nullable = false, length = 31)
     private String nickname;
 
     @CreationTimestamp

--- a/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
@@ -7,6 +7,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.annotations.UpdateTimestamp;
 import java.time.Instant;
+import static com.renzzle.backend.global.common.constant.TimeConstant.CONST_FUTURE_INSTANT;
 import static com.renzzle.backend.global.common.domain.Status.STATUS_IS_NOT_DELETED;
 
 @Entity
@@ -66,7 +67,7 @@ public class UserEntity {
             this.status = Status.getDefaultStatus();
         }
         if(deletedAt == null) {
-            this.deletedAt = Instant.EPOCH;
+            this.deletedAt = CONST_FUTURE_INSTANT;
         }
         if(color == null) {
             this.color = Color.getRandomColor();

--- a/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
@@ -50,13 +50,13 @@ public class UserEntity {
 
     @PrePersist
     public void prePersist() {
-        if (status == null) {
+        if(status == null) {
             this.status = Status.getDefaultStatus();
         }
-        if (color == null) {
+        if(color == null) {
             this.color = Color.getRandomColor();
         }
-        if (level == null) {
+        if(level == null) {
             this.level = UserLevel.getDefaultLevel();
         }
     }

--- a/src/main/java/com/renzzle/backend/domain/user/domain/UserLevel.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/UserLevel.java
@@ -37,7 +37,13 @@ public class UserLevel {
         return userLevel;
     }
 
-    public void setLevel(String levelName) {
+    public static UserLevel getLevel(LevelName levelName) {
+        UserLevel userLevel = new UserLevel();
+        userLevel.name = levelName.name();
+        return userLevel;
+    }
+
+    private void setLevel(String levelName) {
         LevelName[] levelNames = LevelName.values();
         boolean isValid = Arrays.stream(levelNames)
                 .anyMatch(level -> level.name().equals(levelName));

--- a/src/main/java/com/renzzle/backend/domain/user/domain/UserLevel.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/UserLevel.java
@@ -31,12 +31,18 @@ public class UserLevel {
         return new UserLevel(LevelName.BEGINNER.name());
     }
 
+    public static UserLevel getLevel(String levelName) {
+        UserLevel userLevel = new UserLevel();
+        userLevel.setLevel(levelName);
+        return userLevel;
+    }
+
     public void setLevel(String levelName) {
         LevelName[] levelNames = LevelName.values();
         boolean isValid = Arrays.stream(levelNames)
                 .anyMatch(level -> level.name().equals(levelName));
         if(!isValid)
-            throw new CustomException(ErrorCode.VALIDATION_ERROR);
+            throw new IllegalArgumentException("Invalid level name: " + levelName);
 
         this.name = levelName;
     }

--- a/src/main/java/com/renzzle/backend/domain/user/domain/UserLevel.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/UserLevel.java
@@ -47,8 +47,4 @@ public class UserLevel {
         this.name = levelName;
     }
 
-    public void setLevel(LevelName levelName) {
-        this.name = levelName.name();
-    }
-
 }

--- a/src/main/java/com/renzzle/backend/global/common/constant/SortOption.java
+++ b/src/main/java/com/renzzle/backend/global/common/constant/SortOption.java
@@ -1,0 +1,7 @@
+package com.renzzle.backend.global.common.constant;
+
+public enum SortOption {
+
+    RECOMMEND, LATEST, LIKE
+
+}

--- a/src/main/java/com/renzzle/backend/global/common/constant/StringConstant.java
+++ b/src/main/java/com/renzzle/backend/global/common/constant/StringConstant.java
@@ -1,0 +1,7 @@
+package com.renzzle.backend.global.common.constant;
+
+public class StringConstant {
+
+    public static String DELETED_USER = "DELETED_USER";
+
+}

--- a/src/main/java/com/renzzle/backend/global/common/constant/TimeConstant.java
+++ b/src/main/java/com/renzzle/backend/global/common/constant/TimeConstant.java
@@ -1,0 +1,9 @@
+package com.renzzle.backend.global.common.constant;
+
+import java.time.Instant;
+
+public class TimeConstant {
+
+    public static final Instant CONST_FUTURE_INSTANT = Instant.parse("9999-01-01T00:00:00Z");
+
+}

--- a/src/main/java/com/renzzle/backend/global/common/domain/Status.java
+++ b/src/main/java/com/renzzle/backend/global/common/domain/Status.java
@@ -12,8 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Status {
 
-    public static final String DELETED_NICKNAME_SUFFIX = "@deleted";
-    public static final String STATUS_RESTRICTION = "status != 'DELETED'";
+    public static final String STATUS_IS_NOT_DELETED = "status != 'DELETED'";
 
     @Id
     @Column(length = 31)

--- a/src/main/java/com/renzzle/backend/global/common/domain/Status.java
+++ b/src/main/java/com/renzzle/backend/global/common/domain/Status.java
@@ -12,6 +12,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Status {
 
+    public static final String DELETED_NICKNAME_SUFFIX = "@deleted";
+    public static final String STATUS_RESTRICTION = "status != 'DELETED'";
+
     @Id
     @Column(length = 31)
     private String name;

--- a/src/main/java/com/renzzle/backend/global/common/domain/Status.java
+++ b/src/main/java/com/renzzle/backend/global/common/domain/Status.java
@@ -30,8 +30,10 @@ public class Status {
         return new Status(StatusName.CREATED.name());
     }
 
-    public void setStatus(StatusName statusName) {
-        this.name = statusName.name();
+    public static Status getStatus(StatusName statusName) {
+        Status status = new Status();
+        status.name = statusName.name();
+        return status;
     }
 
 }

--- a/src/main/java/com/renzzle/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/renzzle/backend/global/config/SecurityConfig.java
@@ -20,6 +20,8 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.renzzle.backend.domain.auth.domain.Admin.ADMIN;
+
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -50,7 +52,8 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(request -> request
                         .requestMatchers(permitAllRequestMatchers.toArray(new RequestMatcher[0])).permitAll()
-                        .requestMatchers("/admin/**").hasRole("admin")
+                        .requestMatchers(HttpMethod.POST, "/api/lesson").hasRole(ADMIN)
+                        .requestMatchers(HttpMethod.DELETE, "/api/lesson/**").hasRole(ADMIN)
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, userRepository, adminRepository, permitAllRequestMatchers), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/renzzle/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/renzzle/backend/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.renzzle.backend.global.config;
 
+import com.renzzle.backend.domain.auth.dao.AdminRepository;
 import com.renzzle.backend.domain.auth.service.JwtProvider;
 import com.renzzle.backend.domain.user.dao.UserRepository;
 import com.renzzle.backend.global.security.JwtAuthenticationFilter;
@@ -26,6 +27,7 @@ public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
+    private final AdminRepository adminRepository;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
@@ -48,9 +50,10 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(request -> request
                         .requestMatchers(permitAllRequestMatchers.toArray(new RequestMatcher[0])).permitAll()
+                        .requestMatchers("/admin/**").hasRole("admin")
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, userRepository, permitAllRequestMatchers), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, userRepository, adminRepository, permitAllRequestMatchers), UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 

--- a/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
 
     // SQL
     EMPTY_RESULT_ERROR(HttpStatus.NOT_FOUND, "S404", "요청의 결과가 존재하지 않습니다."),
+    CONSTRAINT_VIOLATION_ERROR(HttpStatus.CONFLICT, "S409", "데이터베이스 제약 조건을 위배하였습니다."),
 
     // Auth
     EXCEED_EMAIL_AUTH_REQUEST(HttpStatus.TOO_MANY_REQUESTS, "A429", "이메일 인증 횟수를 초과했습니다."),

--- a/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
@@ -31,7 +31,11 @@ public enum ErrorCode {
     MALFORMED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J4011", "손상되었거나 잘못된 형식의 토큰입니다."),
     UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J4012", "지원하지 않는 형식의 토큰입니다."),
     ILLEGAL_TOKEN(HttpStatus.UNAUTHORIZED, "J4013", "토큰이 없거나 잘못된 형식의 토큰입니다."),
-    CANNOT_PARSE_TOKEN(HttpStatus.UNAUTHORIZED, "J4014", "토큰 파싱에 실패하였습니다.");
+    CANNOT_PARSE_TOKEN(HttpStatus.UNAUTHORIZED, "J4014", "토큰 파싱에 실패하였습니다."),
+
+    // Community Puzzle
+    CANNOT_FIND_COMMUNITY_PUZZLE(HttpStatus.NOT_FOUND, "P404", "해당하는 커뮤니티 퍼즐을 찾을 수 없습니다.")
+    ;
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/renzzle/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/renzzle/backend/global/exception/GlobalExceptionHandler.java
@@ -4,9 +4,11 @@ import com.renzzle.backend.global.util.ApiUtils;
 import jakarta.validation.ValidationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -19,6 +21,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ValidationException.class)
     private ResponseEntity<?> handleValidationException(ValidationException e) {
+        return handleException(e, ErrorCode.VALIDATION_ERROR, e.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<?> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
         return handleException(e, ErrorCode.VALIDATION_ERROR, e.getMessage());
     }
 

--- a/src/main/java/com/renzzle/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/renzzle/backend/global/exception/GlobalExceptionHandler.java
@@ -3,12 +3,13 @@ package com.renzzle.backend.global.exception;
 import com.renzzle.backend.global.util.ApiUtils;
 import jakarta.validation.ValidationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import static com.renzzle.backend.global.util.ErrorUtils.getStakeTrace;
 
 @Slf4j
 @RestControllerAdvice
@@ -34,13 +35,19 @@ public class GlobalExceptionHandler {
         return handleException(e, ErrorCode.EMPTY_RESULT_ERROR, ErrorCode.EMPTY_RESULT_ERROR.getMessage());
     }
 
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    private ResponseEntity<?> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        return handleException(e, ErrorCode.CONSTRAINT_VIOLATION_ERROR, ErrorCode.CONSTRAINT_VIOLATION_ERROR.getMessage());
+    }
+
     @ExceptionHandler(CustomException.class)
     protected ResponseEntity<?> handleBusinessException(CustomException e) {
         return handleException(e, e.getErrorCode(), e.getMessage());
     }
 
     private ResponseEntity<?> handleException(Exception e, ErrorCode errorCode, String message) {
-        log.error("error occurs! {}: {}", errorCode, e.getMessage());
+        log.error(getStakeTrace(e));
+        log.error("[{}] {}: {}", errorCode, e.getClass(), e.getMessage());
         return ApiUtils.error(ErrorResponse.of(errorCode, message));
     }
 

--- a/src/main/java/com/renzzle/backend/global/init/DataInitializer.java
+++ b/src/main/java/com/renzzle/backend/global/init/DataInitializer.java
@@ -1,5 +1,6 @@
 package com.renzzle.backend.global.init;
 
+import com.renzzle.backend.domain.auth.service.AccountService;
 import com.renzzle.backend.domain.puzzle.domain.Difficulty;
 import com.renzzle.backend.domain.puzzle.domain.WinColor;
 import com.renzzle.backend.domain.user.domain.Color;
@@ -7,17 +8,25 @@ import com.renzzle.backend.domain.user.domain.UserLevel;
 import com.renzzle.backend.global.common.domain.Status;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
+import static com.renzzle.backend.domain.auth.domain.Admin.ADMIN;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class DataInitializer implements CommandLineRunner {
 
+    private final AccountService accountService;
     private final JdbcTemplate jdbcTemplate;
+
+    @Value("spring.mail.username")
+    private String adminEmail;
+    @Value("spring.email.password")
+    private String adminPassword;
 
     @Override
     public void run(String... args) {
@@ -29,13 +38,16 @@ public class DataInitializer implements CommandLineRunner {
                     getInsertEnumSql("difficulty", Difficulty.DifficultyName.class),
                     getInsertEnumSql("win_color", WinColor.WinColorName.class)
             );
+
+            if(!accountService.isDuplicateNickname(ADMIN))
+                accountService.createNewUser(adminEmail, adminPassword, ADMIN);
         } catch(DuplicateKeyException e) {
             log.warn("Data already exists");
         }
     }
 
     private <E extends Enum<E>> String getInsertEnumSql(String tableName, Class<E> enumClass) {
-        StringBuilder sqlBuilder = new StringBuilder("INSERT INTO ");
+        StringBuilder sqlBuilder = new StringBuilder("INSERT IGNORE INTO ");
         sqlBuilder.append(tableName).append(" (name) VALUES ");
 
         E[] enumConstants = enumClass.getEnumConstants();

--- a/src/main/java/com/renzzle/backend/global/init/DataInitializer.java
+++ b/src/main/java/com/renzzle/backend/global/init/DataInitializer.java
@@ -1,5 +1,10 @@
 package com.renzzle.backend.global.init;
 
+import com.renzzle.backend.domain.puzzle.domain.Difficulty;
+import com.renzzle.backend.domain.puzzle.domain.WinColor;
+import com.renzzle.backend.domain.user.domain.Color;
+import com.renzzle.backend.domain.user.domain.UserLevel;
+import com.renzzle.backend.global.common.domain.Status;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
@@ -18,15 +23,30 @@ public class DataInitializer implements CommandLineRunner {
     public void run(String... args) {
         try {
             jdbcTemplate.batchUpdate(
-                    "INSERT INTO status (name) VALUES ('CREATED'), ('DELETED')",
-                    "INSERT INTO user_level (name) VALUES ('BEGINNER'), ('INTERMEDIATE'), ('ADVANCED')",
-                    "INSERT INTO color (name) VALUES ('RED'), ('ORANGE'), ('GREEN'), ('BLUE'), ('INDIGO'), ('PURPLE'), ('DARK_RED'), ('DARK_ORANGE'), ('DARK_GREEN'), ('DARK_BLUE'), ('DARK_INDIGO'), ('DARK_PURPLE')",
-                    "INSERT INTO difficulty (name) VALUES ('HIGH'), ('MIDDLE'), ('LOW')",
-                    "INSERT INTO win_color (name) VALUES ('BLACK'), ('WHITE')"
+                    getInsertEnumSql("status", Status.StatusName.class),
+                    getInsertEnumSql("user_level", UserLevel.LevelName.class),
+                    getInsertEnumSql("color", Color.ColorName.class),
+                    getInsertEnumSql("difficulty", Difficulty.DifficultyName.class),
+                    getInsertEnumSql("win_color", WinColor.WinColorName.class)
             );
         } catch(DuplicateKeyException e) {
             log.warn("Data already exists");
         }
+    }
+
+    private <E extends Enum<E>> String getInsertEnumSql(String tableName, Class<E> enumClass) {
+        StringBuilder sqlBuilder = new StringBuilder("INSERT INTO ");
+        sqlBuilder.append(tableName).append(" (name) VALUES ");
+
+        E[] enumConstants = enumClass.getEnumConstants();
+        for (int i = 0; i < enumConstants.length; i++) {
+            sqlBuilder.append("('").append(enumConstants[i].name()).append("')");
+            if (i < enumConstants.length - 1) {
+                sqlBuilder.append(", ");
+            }
+        }
+
+        return sqlBuilder.toString();
     }
 
 }

--- a/src/main/java/com/renzzle/backend/global/init/DataInitializer.java
+++ b/src/main/java/com/renzzle/backend/global/init/DataInitializer.java
@@ -25,6 +25,12 @@ public class DataInitializer implements CommandLineRunner {
 
             String colorSql = "INSERT INTO color (name) VALUES ('RED'), ('ORANGE'), ('GREEN'), ('BLUE'), ('INDIGO'), ('PURPLE'), ('DARK_RED'), ('DARK_ORANGE'), ('DARK_GREEN'), ('DARK_BLUE'), ('DARK_INDIGO'), ('DARK_PURPLE')";
             jdbcTemplate.execute(colorSql);
+
+            String difficultySql = "INSERT INTO difficulty (name) VALUES ('HIGH'), ('MIDDLE'), ('LOW')";
+            jdbcTemplate.execute(difficultySql);
+
+            String winColorSql = "INSERT INTO win_color (name) VALUES ('BLACK'), ('WHITE')";
+            jdbcTemplate.execute(winColorSql);
         } catch(DuplicateKeyException e) {
             log.warn("Data already exists");
         }

--- a/src/main/java/com/renzzle/backend/global/init/DataInitializer.java
+++ b/src/main/java/com/renzzle/backend/global/init/DataInitializer.java
@@ -1,9 +1,12 @@
 package com.renzzle.backend.global.init;
 
+import com.renzzle.backend.domain.auth.dao.AdminRepository;
+import com.renzzle.backend.domain.auth.domain.Admin;
 import com.renzzle.backend.domain.auth.service.AccountService;
 import com.renzzle.backend.domain.puzzle.domain.Difficulty;
 import com.renzzle.backend.domain.puzzle.domain.WinColor;
 import com.renzzle.backend.domain.user.domain.Color;
+import com.renzzle.backend.domain.user.domain.UserEntity;
 import com.renzzle.backend.domain.user.domain.UserLevel;
 import com.renzzle.backend.global.common.domain.Status;
 import lombok.RequiredArgsConstructor;
@@ -21,11 +24,12 @@ import static com.renzzle.backend.domain.auth.domain.Admin.ADMIN;
 public class DataInitializer implements CommandLineRunner {
 
     private final AccountService accountService;
+    private final AdminRepository adminRepository;
     private final JdbcTemplate jdbcTemplate;
 
-    @Value("spring.mail.username")
+    @Value("${spring.mail.username}")
     private String adminEmail;
-    @Value("spring.email.password")
+    @Value("${spring.mail.password}")
     private String adminPassword;
 
     @Override
@@ -39,8 +43,10 @@ public class DataInitializer implements CommandLineRunner {
                     getInsertEnumSql("win_color", WinColor.WinColorName.class)
             );
 
-            if(!accountService.isDuplicateNickname(ADMIN))
-                accountService.createNewUser(adminEmail, adminPassword, ADMIN);
+            if(!accountService.isDuplicateNickname(ADMIN)) {
+                UserEntity user = accountService.createNewUser(adminEmail, adminPassword, ADMIN);
+                adminRepository.save(Admin.builder().user(user).build());
+            }
         } catch(DuplicateKeyException e) {
             log.warn("Data already exists");
         }

--- a/src/main/java/com/renzzle/backend/global/init/DataInitializer.java
+++ b/src/main/java/com/renzzle/backend/global/init/DataInitializer.java
@@ -17,20 +17,13 @@ public class DataInitializer implements CommandLineRunner {
     @Override
     public void run(String... args) {
         try {
-            String statusSql = "INSERT INTO status (name) VALUES ('CREATED'), ('DELETED')";
-            jdbcTemplate.execute(statusSql);
-
-            String userLevelSql = "INSERT INTO user_level (name) VALUES ('BEGINNER'), ('INTERMEDIATE'), ('ADVANCED')";
-            jdbcTemplate.execute(userLevelSql);
-
-            String colorSql = "INSERT INTO color (name) VALUES ('RED'), ('ORANGE'), ('GREEN'), ('BLUE'), ('INDIGO'), ('PURPLE'), ('DARK_RED'), ('DARK_ORANGE'), ('DARK_GREEN'), ('DARK_BLUE'), ('DARK_INDIGO'), ('DARK_PURPLE')";
-            jdbcTemplate.execute(colorSql);
-
-            String difficultySql = "INSERT INTO difficulty (name) VALUES ('HIGH'), ('MIDDLE'), ('LOW')";
-            jdbcTemplate.execute(difficultySql);
-
-            String winColorSql = "INSERT INTO win_color (name) VALUES ('BLACK'), ('WHITE')";
-            jdbcTemplate.execute(winColorSql);
+            jdbcTemplate.batchUpdate(
+                    "INSERT INTO status (name) VALUES ('CREATED'), ('DELETED')",
+                    "INSERT INTO user_level (name) VALUES ('BEGINNER'), ('INTERMEDIATE'), ('ADVANCED')",
+                    "INSERT INTO color (name) VALUES ('RED'), ('ORANGE'), ('GREEN'), ('BLUE'), ('INDIGO'), ('PURPLE'), ('DARK_RED'), ('DARK_ORANGE'), ('DARK_GREEN'), ('DARK_BLUE'), ('DARK_INDIGO'), ('DARK_PURPLE')",
+                    "INSERT INTO difficulty (name) VALUES ('HIGH'), ('MIDDLE'), ('LOW')",
+                    "INSERT INTO win_color (name) VALUES ('BLACK'), ('WHITE')"
+            );
         } catch(DuplicateKeyException e) {
             log.warn("Data already exists");
         }

--- a/src/main/java/com/renzzle/backend/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/renzzle/backend/global/security/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.renzzle.backend.global.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.renzzle.backend.domain.auth.dao.AdminRepository;
 import com.renzzle.backend.domain.auth.domain.GrantType;
 import com.renzzle.backend.domain.auth.service.JwtProvider;
 import com.renzzle.backend.domain.user.dao.UserRepository;
@@ -25,8 +26,10 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import static com.renzzle.backend.domain.auth.domain.Admin.ADMIN;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -34,6 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
+    private final AdminRepository adminRepository;
     private final List<RequestMatcher> permitAllRequestMatchers;
 
     @Override
@@ -63,7 +67,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if(user.isEmpty())
             throw new CustomException(ErrorCode.GLOBAL_NOT_FOUND);
 
-        return new UserDetailsImpl(user.get(), user.get().getPassword(), null);
+        List<String> roles = new ArrayList<>();
+        if(adminRepository.existsByUser(user.get()))
+            roles.add(ADMIN);
+
+        return new UserDetailsImpl(user.get(), user.get().getPassword(), roles);
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/src/main/java/com/renzzle/backend/global/util/ApiUtils.java
+++ b/src/main/java/com/renzzle/backend/global/util/ApiUtils.java
@@ -6,8 +6,7 @@ import org.springframework.http.ResponseEntity;
 
 public class ApiUtils {
 
-    private ApiUtils() {
-    }
+    private ApiUtils() {}
 
     public static <T> ApiResponse<T> success(T response) {
         return ApiResponse.create(true, response, null);

--- a/src/main/java/com/renzzle/backend/global/util/BoardUtils.java
+++ b/src/main/java/com/renzzle/backend/global/util/BoardUtils.java
@@ -1,5 +1,8 @@
 package com.renzzle.backend.global.util;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -57,12 +60,21 @@ public class BoardUtils {
         StringBuilder result = new StringBuilder();
 
         for (Integer num : minB) {
-            char c = (char) (num + 32);
-            result.append(c);
+            result.append(num);
         }
         for (Integer num : minW) {
-            char c = (char) (num + 32);
-            result.append(c);
+            result.append(num);
+        }
+
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update(result.toString().getBytes(StandardCharsets.UTF_8));
+            result = new StringBuilder();
+            for (byte b : md.digest()) {
+                result.append(String.format("%02x", b));
+            }
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
         }
 
         return result.toString();

--- a/src/main/java/com/renzzle/backend/global/util/BoardUtils.java
+++ b/src/main/java/com/renzzle/backend/global/util/BoardUtils.java
@@ -1,0 +1,162 @@
+package com.renzzle.backend.global.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class BoardUtils {
+
+    private BoardUtils() {}
+
+    public static String makeBoardKey(String boardStatus) {
+        if(boardStatus == null || boardStatus.isBlank())
+            throwIllegalBoardStatusException(boardStatus);
+
+        List<List<Integer>> blackPosLists = new ArrayList<>();
+        List<List<Integer>> whitePosLists = new ArrayList<>();
+
+        for(int i = 0; i < 8; i++) {
+            blackPosLists.add(new ArrayList<>());
+            whitePosLists.add(new ArrayList<>());
+        }
+
+        // parse board status string
+        for(int i = 0; i < boardStatus.length();) {
+            int p = getBoardPositionFromString(boardStatus, i);
+            List<Integer> posList = getAllSymmetryPos(p);
+
+            for(int j = 0; j < 8; j++) {
+                if(blackPosLists.get(j).size() <= whitePosLists.get(j).size())
+                    blackPosLists.get(j).add(posList.get(j));
+                else whitePosLists.get(j).add(posList.get(j));
+            }
+
+            // calculate increment based on position
+            i += ((p - 1) % 15 < 9) ? 2 : 3;
+        }
+
+        // sort all lists
+        for(int i = 0; i < 8; i++) {
+            Collections.sort(blackPosLists.get(i));
+            Collections.sort(whitePosLists.get(i));
+        }
+
+        // find minimum value list
+        List<Integer> minB = blackPosLists.get(0);
+        List<Integer> minW = whitePosLists.get(0);
+        for(int i = 1; i < 8; i++) {
+            if(compareList(minB, blackPosLists.get(i)) > 0) {
+                minB = blackPosLists.get(i);
+            }
+            if(compareList(minW, whitePosLists.get(i)) > 0) {
+                minW = whitePosLists.get(i);
+            }
+        }
+
+        // make string key
+        StringBuilder result = new StringBuilder();
+
+        for (Integer num : minB) {
+            char c = (char) (num + 32);
+            result.append(c);
+        }
+        for (Integer num : minW) {
+            char c = (char) (num + 32);
+            result.append(c);
+        }
+
+        return result.toString();
+    }
+
+    private static int compareList(List<Integer> l1, List<Integer> l2) {
+        for(int i = 0; i < l1.size(); i++) {
+            if(l1.get(i) > l2.get(i)) return 1;
+            else if(l1.get(i) < l2.get(i)) return -1;
+        }
+        return 0;
+    }
+
+    private static List<Integer> getAllSymmetryPos(int p) {
+        List<Integer> posList = new ArrayList<>();
+
+        int tmp = p;
+        for(int i = 0; i < 4; i++) {
+            posList.add(tmp);
+            tmp = rotate90(tmp);
+        }
+
+        tmp = xAxisSymmetry(p);
+        for(int i = 0; i < 4; i++) {
+            posList.add(tmp);
+            tmp = rotate90(tmp);
+        }
+
+        return posList;
+    }
+
+    private static int rotate90(int n) {
+        int x = (n - 1) / 15;
+        int y = ((n % 15) == 0) ? 15 : (n % 15);
+
+        int cx = 15 - x;
+        int cy = y - 1;
+
+        return (cy * 15) + cx;
+    }
+
+    private static int xAxisSymmetry(int n) {
+        int y = ((n % 15) == 0) ? 15 : (n % 15);
+        return n - (2 * y) + 16;
+    }
+
+    private static int getBoardPositionFromString(String boardStatus, int index) {
+        char charPart = boardStatus.charAt(index);
+
+        if(!isCharInAtoO(charPart))
+            throwIllegalBoardStatusException(boardStatus);
+
+        int n = (charPart - 'a') * 15;
+
+        // determine the number of digits
+        if(!isNonZeroDigit(boardStatus.charAt(index + 1)))
+            throwIllegalBoardStatusException(boardStatus);
+        int digitsNum = calculateDigitsNum(boardStatus, index + 1);
+
+        String numberPart = boardStatus.substring(index + 1, index + 1 + digitsNum);
+        int tmp = Integer.parseInt(numberPart);
+        if(tmp < 1 || tmp > 15)
+            throwIllegalBoardStatusException(boardStatus);
+
+        n += tmp;
+
+        return n;
+    }
+
+    private static void throwIllegalBoardStatusException(String boardStatus) {
+        if(boardStatus == null)
+            throw new NullPointerException("Board status is null");
+        throw new IllegalArgumentException("Invalid board status string: " + boardStatus);
+    }
+
+    private static boolean isCharInAtoO(char c) {
+        return 'a' <= c && c <= 'o';
+    }
+
+    private static boolean isDigit(char c) {
+        return '0' <= c && c <= '9';
+    }
+
+    private static boolean isNonZeroDigit(char c) {
+        return '1' <= c && c <= '9';
+    }
+
+    private static int calculateDigitsNum(String boardStatus, int startIndex) {
+        int digitsNum = 0;
+        while (startIndex + digitsNum < boardStatus.length()
+                && isDigit(boardStatus.charAt(startIndex + digitsNum))) {
+            digitsNum++;
+        }
+        return digitsNum;
+    }
+
+}

--- a/src/main/java/com/renzzle/backend/global/util/BoardUtils.java
+++ b/src/main/java/com/renzzle/backend/global/util/BoardUtils.java
@@ -68,6 +68,27 @@ public class BoardUtils {
         return result.toString();
     }
 
+    public static boolean validBoardString(String str) {
+        for(int i = 0; i < str.length();) {
+            char charPart = str.charAt(i);
+            if(!isCharInAtoO(charPart))
+                return false;
+
+            if(!isNonZeroDigit(str.charAt(i + 1)))
+                return false;
+            int digitsNum = calculateDigitsNum(str, i + 1);
+
+            String numberPart = str.substring(i + 1, i + 1 + digitsNum);
+            int tmp = Integer.parseInt(numberPart);
+            if(tmp < 1 || tmp > 15)
+                return false;
+
+            i += (digitsNum + 1);
+        }
+
+        return true;
+    }
+
     private static int compareList(List<Integer> l1, List<Integer> l2) {
         for(int i = 0; i < l1.size(); i++) {
             if(l1.get(i) > l2.get(i)) return 1;

--- a/src/main/java/com/renzzle/backend/global/util/ErrorUtils.java
+++ b/src/main/java/com/renzzle/backend/global/util/ErrorUtils.java
@@ -2,13 +2,22 @@ package com.renzzle.backend.global.util;
 
 import org.springframework.validation.BindingResult;
 
-public class BindingResultUtils {
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public class ErrorUtils {
 
     public static String getErrorMessages(BindingResult bindingResult) {
         StringBuilder errorMessages = new StringBuilder();
         bindingResult.getAllErrors()
                 .forEach(error -> errorMessages.append(error.getDefaultMessage()).append(". "));
         return errorMessages.toString();
+    }
+
+    public static String getStakeTrace(Exception e) {
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
     }
 
 }

--- a/src/main/java/com/renzzle/backend/global/validation/BoardValidator.java
+++ b/src/main/java/com/renzzle/backend/global/validation/BoardValidator.java
@@ -1,0 +1,22 @@
+package com.renzzle.backend.global.validation;
+
+import com.renzzle.backend.global.util.BoardUtils;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class BoardValidator implements ConstraintValidator<ValidBoardString, String> {
+
+    @Override
+    public void initialize(ValidBoardString constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if(value == null) return false;
+        if(value.isBlank()) return false;
+
+        return BoardUtils.validBoardString(value);
+    }
+
+}

--- a/src/main/java/com/renzzle/backend/global/validation/EnumValidator.java
+++ b/src/main/java/com/renzzle/backend/global/validation/EnumValidator.java
@@ -14,13 +14,13 @@ public class EnumValidator implements ConstraintValidator<ValidEnum, String> {
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
-        if (value == null) return false;
+        if(value == null) return false;
 
         Object[] enumValues = this.annotation.enumClass().getEnumConstants();
-        if (enumValues == null) return false;
+        if(enumValues == null) return false;
 
-        for (Object enumValue : enumValues) {
-            if (enumValue.toString().equalsIgnoreCase(value)) {
+        for(Object enumValue : enumValues) {
+            if(enumValue.toString().equalsIgnoreCase(value)) {
                 return true;
             }
         }

--- a/src/main/java/com/renzzle/backend/global/validation/EnumValidator.java
+++ b/src/main/java/com/renzzle/backend/global/validation/EnumValidator.java
@@ -1,0 +1,31 @@
+package com.renzzle.backend.global.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<ValidEnum, String> {
+
+    private ValidEnum annotation;
+
+    @Override
+    public void initialize(ValidEnum constraintAnnotation) {
+        this.annotation = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) return false;
+
+        Object[] enumValues = this.annotation.enumClass().getEnumConstants();
+        if (enumValues == null) return false;
+
+        for (Object enumValue : enumValues) {
+            if (enumValue.toString().equalsIgnoreCase(value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/src/main/java/com/renzzle/backend/global/validation/ValidBoardString.java
+++ b/src/main/java/com/renzzle/backend/global/validation/ValidBoardString.java
@@ -6,13 +6,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Constraint(validatedBy = EnumValidator.class)
+@Constraint(validatedBy = BoardValidator.class)
 @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface ValidEnum {
+public @interface ValidBoardString {
 
-    String message() default "요구되는 Enum 타입의 데이터가 아닙니다";
-
-    Class<? extends java.lang.Enum<?>> enumClass();
+    String message() default "올바른 Board String 형식이 아닙니다";
 
 }

--- a/src/main/java/com/renzzle/backend/global/validation/ValidBoardString.java
+++ b/src/main/java/com/renzzle/backend/global/validation/ValidBoardString.java
@@ -1,6 +1,8 @@
 package com.renzzle.backend.global.validation;
 
 import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -12,5 +14,7 @@ import java.lang.annotation.Target;
 public @interface ValidBoardString {
 
     String message() default "올바른 Board String 형식이 아닙니다";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
 
 }

--- a/src/main/java/com/renzzle/backend/global/validation/ValidEnum.java
+++ b/src/main/java/com/renzzle/backend/global/validation/ValidEnum.java
@@ -1,0 +1,23 @@
+package com.renzzle.backend.global.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = EnumValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidEnum {
+
+    String message() default "요구되는 Enum 타입의 데이터가 아닙니다";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    Class<? extends java.lang.Enum<?>> enumClass();
+
+}

--- a/src/main/java/com/renzzle/backend/global/validation/ValidEnum.java
+++ b/src/main/java/com/renzzle/backend/global/validation/ValidEnum.java
@@ -1,6 +1,8 @@
 package com.renzzle.backend.global.validation;
 
 import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -12,7 +14,8 @@ import java.lang.annotation.Target;
 public @interface ValidEnum {
 
     String message() default "요구되는 Enum 타입의 데이터가 아닙니다";
-
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
     Class<? extends java.lang.Enum<?>> enumClass();
 
 }

--- a/src/test/java/com/renzzle/backend/util/BoardUtilsTest.java
+++ b/src/test/java/com/renzzle/backend/util/BoardUtilsTest.java
@@ -1,0 +1,120 @@
+package com.renzzle.backend.util;
+
+import com.renzzle.backend.global.util.BoardUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class BoardUtilsTest {
+
+    @Test
+    public void getBoardPositionFromStringTest() throws Exception {
+        // get private method
+        Method method = BoardUtils.class.getDeclaredMethod("getBoardPositionFromString", String.class, int.class);
+        method.setAccessible(true);
+
+        // b15 == 30
+        int position = (int) method.invoke(null, "a1b15c7", 2);
+        Assertions.assertEquals(position, 30);
+
+        // a1 == 1
+        position = (int) method.invoke(null, "a1b15c7", 0);
+        Assertions.assertEquals(position, 1);
+
+        // c7 == 37
+        position = (int) method.invoke(null, "a1b15c7", 5);
+        Assertions.assertEquals(position, 37);
+
+        // number part more than 15
+        Exception exception = Assertions.assertThrows(InvocationTargetException.class, () -> {
+            method.invoke(null, "b16", 0);
+        });
+        Throwable cause = exception.getCause();
+        Assertions.assertInstanceOf(IllegalArgumentException.class, cause);
+
+        // number part more than 15
+        exception = Assertions.assertThrows(InvocationTargetException.class, () -> {
+            method.invoke(null, "b1111", 0);
+        });
+        cause = exception.getCause();
+        Assertions.assertInstanceOf(IllegalArgumentException.class, cause);
+
+        // character part invalid character
+        exception = Assertions.assertThrows(InvocationTargetException.class, () -> {
+            method.invoke(null, "r13", 0);
+        });
+        cause = exception.getCause();
+        Assertions.assertInstanceOf(IllegalArgumentException.class, cause);
+
+        // number part invalid structure
+        exception = Assertions.assertThrows(InvocationTargetException.class, () -> {
+            method.invoke(null, "b03", 0);
+        });
+        cause = exception.getCause();
+        Assertions.assertInstanceOf(IllegalArgumentException.class, cause);
+    }
+
+    @Test
+    public void rotate90Test() throws Exception {
+        Method getBoardPositionFromString = BoardUtils.class.getDeclaredMethod("getBoardPositionFromString", String.class, int.class);
+        getBoardPositionFromString.setAccessible(true);
+
+        Method rotate90 = BoardUtils.class.getDeclaredMethod("rotate90", int.class);
+        rotate90.setAccessible(true);
+
+        // case 1
+        int pos = (int) getBoardPositionFromString.invoke(null, "a1", 0);
+        int pos90 = (int) getBoardPositionFromString.invoke(null, "a15", 0);
+        int resultPos = (int) rotate90.invoke(null, pos);
+        Assertions.assertEquals(pos90, resultPos);
+
+        // case 2
+        pos = (int) getBoardPositionFromString.invoke(null, "g5", 0);
+        pos90 = (int) getBoardPositionFromString.invoke(null, "e9", 0);
+        resultPos = (int) rotate90.invoke(null, pos);
+        Assertions.assertEquals(pos90, resultPos);
+
+        // case 3
+        pos = (int) getBoardPositionFromString.invoke(null, "h8", 0);
+        pos90 = (int) getBoardPositionFromString.invoke(null, "h8", 0);
+        resultPos = (int) rotate90.invoke(null, pos);
+        Assertions.assertEquals(pos90, resultPos);
+    }
+
+    @Test
+    public void xAxisSymmetryTest() throws Exception {
+        Method getBoardPositionFromString = BoardUtils.class.getDeclaredMethod("getBoardPositionFromString", String.class, int.class);
+        getBoardPositionFromString.setAccessible(true);
+
+        Method xAxisSymmetry = BoardUtils.class.getDeclaredMethod("xAxisSymmetry", int.class);
+        xAxisSymmetry.setAccessible(true);
+
+        // case 1
+        int pos = (int) getBoardPositionFromString.invoke(null, "a1", 0);
+        int posXSymmetry = (int) getBoardPositionFromString.invoke(null, "a15", 0);
+        int resultPos = (int) xAxisSymmetry.invoke(null, pos);
+        Assertions.assertEquals(posXSymmetry, resultPos);
+
+        // case 2
+        pos = (int) getBoardPositionFromString.invoke(null, "g3", 0);
+        posXSymmetry = (int) getBoardPositionFromString.invoke(null, "g13", 0);
+        resultPos = (int) xAxisSymmetry.invoke(null, pos);
+        Assertions.assertEquals(posXSymmetry, resultPos);
+
+        // case 3
+        pos = (int) getBoardPositionFromString.invoke(null, "h8", 0);
+        posXSymmetry = (int) getBoardPositionFromString.invoke(null, "h8", 0);
+        resultPos = (int) xAxisSymmetry.invoke(null, pos);
+        Assertions.assertEquals(posXSymmetry, resultPos);
+    }
+
+    @Test
+    public void makeBoardKeyTest() {
+        String s1 = BoardUtils.makeBoardKey("h8i9i7h7j8i8j9k9");
+        String s2 = BoardUtils.makeBoardKey("i7k9j8h7h8i8j9i9");
+
+        Assertions.assertEquals(s1, s2);
+    }
+
+}

--- a/src/test/java/com/renzzle/backend/util/BoardUtilsTest.java
+++ b/src/test/java/com/renzzle/backend/util/BoardUtilsTest.java
@@ -113,8 +113,11 @@ public class BoardUtilsTest {
     public void makeBoardKeyTest() {
         String s1 = BoardUtils.makeBoardKey("h8i9i7h7j8i8j9k9");
         String s2 = BoardUtils.makeBoardKey("i7k9j8h7h8i8j9i9");
-
         Assertions.assertEquals(s1, s2);
+
+        s1 = BoardUtils.makeBoardKey("h8j9h7");
+        s2 = BoardUtils.makeBoardKey("h8j9h7h6h5h4h3h2a11n7");
+        Assertions.assertNotEquals(s1, s2);
     }
 
 }


### PR DESCRIPTION
### ✏️ 작업 개요
커뮤니티 퍼즐 관련 API 작업 및 레슨 퍼즐 관련 엔티티 생성

### 🔨 작업 상세 내용
1. GET /api/community/puzzle?id=&size=&sort= API 완성
-> 페이징 처리 No offset 방식 적용 
2. POST /api/community/puzzle API 완성
3. POST /api/community/solve API 완성
4. POST /api/community/fail API 완성
5. User entity & Community puzzle entity soft delete 구현
6. role을 통한 Admin 구현 (서버를 재구동하면 자동으로 admin 계정 추가)
7. 유니크한 Board key를 만드는 Board Util 구현 (SHA-256 알고리즘 적용, 동형일 경우 같은 Key 나오도록)
8. 레슨 문제쪽 엔티티 구현

### 💡 생각해볼 문제
- 관리자 용 API를 추가해야 함 -> API 문서에 추가해두었음 (레슨 문제 쪽)
- 레슨 문제에 인덱스 따로 추가하여 관리 -> 중간 순서에 새 문제를 넣을 경우 뒤쪽 문제들을 한칸씩 미뤄야 함
- cascade 관련 고민해볼 부분 (구독 쪽에도 적용이 잘 되어 있어야 함. @OnDelete와 @Cascade의 차이)
- 비즈니스 로직은 최대한 Service 쪽으로 
- 페이징 처리 관련 인덱싱 관련하여 성능적으로 고민하였고, 추천순이나 검색 관련해서는 어떻게 구현해야할지 고민해야함
- 현재 soft delete 구현 부분이 deleted_at을 따로 두어 지워진 시점을 통해 unique를 보장하는 로직임. created 상태일 경우는 deleted_at의 부분이 특정한 먼 미래 시점으로 고정되어 있음(null은 같은 값으로 취급하지 않기 때문). 이 부분이 더 나은 방법으로 soft delete를 구현할 수 있을지 고민
