### PR TITLE
레슨 퍼즐 API 구현중

### DIFF
--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/LessonController.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/LessonController.java
@@ -1,18 +1,21 @@
 package com.renzzle.backend.domain.puzzle.api;
 
 import com.renzzle.backend.domain.puzzle.api.request.AddLessonPuzzleRequest;
+import com.renzzle.backend.domain.puzzle.api.request.SolveLessonPuzzleRequest;
+import com.renzzle.backend.domain.puzzle.api.response.SolveLessonPuzzleResponse;
 import com.renzzle.backend.domain.puzzle.domain.LessonPuzzle;
 import com.renzzle.backend.domain.puzzle.service.LessonService;
 import com.renzzle.backend.global.common.response.ApiResponse;
+import com.renzzle.backend.global.security.UserDetailsImpl;
 import com.renzzle.backend.global.util.ApiUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.ValidationException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
-
 import static com.renzzle.backend.global.util.ErrorUtils.getErrorMessages;
 
 @RestController
@@ -23,7 +26,7 @@ public class LessonController {
 
     private final LessonService lessonService;
 
-    @Operation(summary = "Add lesson puzzle", description = "Add lesson puzzle and only admins are available")
+    @Operation(summary = "Add lesson puzzle", description = "Add lesson puzzle & Only admins are available")
     @PostMapping("")
     public ApiResponse<Long> addLessonPuzzle(
             @Valid @RequestBody AddLessonPuzzleRequest request,
@@ -38,10 +41,29 @@ public class LessonController {
         return ApiUtils.success(puzzle.getId());
     }
 
+    @Operation(summary = "Delete lesson puzzle", description = "Delete lesson puzzle & Only admins are available")
     @DeleteMapping("/{lessonId}")
     public ApiResponse<Object> deleteLessonPuzzle(@PathVariable("lessonId") Long lessonId) {
         lessonService.deleteLessonPuzzle(lessonId);
         return ApiUtils.success(null);
+    }
+
+    @Operation(summary = "Solve lesson puzzle", description = "Return unlocked lesson puzzle id (can be null)")
+    @PostMapping("/solve")
+    public ApiResponse<SolveLessonPuzzleResponse> solveLessonPuzzle(
+            @Valid @RequestBody SolveLessonPuzzleRequest request,
+            @AuthenticationPrincipal UserDetailsImpl user,
+            BindingResult bindingResult
+    ) {
+        if(bindingResult.hasErrors()) {
+            throw new ValidationException(getErrorMessages(bindingResult));
+        }
+
+        Long unlockedId = lessonService.solveLessonPuzzle(user.getUser(), request.puzzleId());
+
+        return ApiUtils.success(SolveLessonPuzzleResponse.builder()
+                .unlockedId(unlockedId)
+                .build());
     }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/LessonController.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/LessonController.java
@@ -11,10 +11,8 @@ import jakarta.validation.Valid;
 import jakarta.validation.ValidationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
 import static com.renzzle.backend.global.util.ErrorUtils.getErrorMessages;
 
 @RestController
@@ -38,6 +36,12 @@ public class LessonController {
         LessonPuzzle puzzle = lessonService.createLessonPuzzle(request);
 
         return ApiUtils.success(puzzle.getId());
+    }
+
+    @DeleteMapping("/{lessonId}")
+    public ApiResponse<Object> deleteLessonPuzzle(@PathVariable("lessonId") Long lessonId) {
+        lessonService.deleteLessonPuzzle(lessonId);
+        return ApiUtils.success(null);
     }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/LessonController.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/LessonController.java
@@ -1,0 +1,40 @@
+package com.renzzle.backend.domain.puzzle.api;
+
+import com.renzzle.backend.domain.puzzle.api.request.AddLessonPuzzleRequest;
+import com.renzzle.backend.domain.puzzle.service.LessonService;
+import com.renzzle.backend.global.common.response.ApiResponse;
+import com.renzzle.backend.global.util.ApiUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.ValidationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import static com.renzzle.backend.global.util.ErrorUtils.getErrorMessages;
+
+@RestController
+@RequestMapping("/api/lesson")
+@RequiredArgsConstructor
+@Tag(name = "Lesson Puzzle API", description = "Lesson Puzzle API")
+public class LessonController {
+
+    private final LessonService lessonService;
+
+    @Operation(summary = "Add lesson puzzle", description = "Add lesson puzzle and only admins are available")
+    @PostMapping("")
+    public ApiResponse<Long> addLessonPuzzle(
+            @Valid @RequestBody AddLessonPuzzleRequest request,
+            BindingResult bindingResult
+    ) {
+        if(bindingResult.hasErrors()) {
+            throw new ValidationException(getErrorMessages(bindingResult));
+        }
+
+        return ApiUtils.success(-1L);
+    }
+
+}

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/LessonController.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/LessonController.java
@@ -1,6 +1,7 @@
 package com.renzzle.backend.domain.puzzle.api;
 
 import com.renzzle.backend.domain.puzzle.api.request.AddLessonPuzzleRequest;
+import com.renzzle.backend.domain.puzzle.domain.LessonPuzzle;
 import com.renzzle.backend.domain.puzzle.service.LessonService;
 import com.renzzle.backend.global.common.response.ApiResponse;
 import com.renzzle.backend.global.util.ApiUtils;
@@ -34,7 +35,9 @@ public class LessonController {
             throw new ValidationException(getErrorMessages(bindingResult));
         }
 
-        return ApiUtils.success(-1L);
+        LessonPuzzle puzzle = lessonService.createLessonPuzzle(request);
+
+        return ApiUtils.success(puzzle.getId());
     }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/LessonController.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/LessonController.java
@@ -2,6 +2,7 @@ package com.renzzle.backend.domain.puzzle.api;
 
 import com.renzzle.backend.domain.puzzle.api.request.AddLessonPuzzleRequest;
 import com.renzzle.backend.domain.puzzle.api.request.SolveLessonPuzzleRequest;
+import com.renzzle.backend.domain.puzzle.api.response.GetLessonProgressResponse;
 import com.renzzle.backend.domain.puzzle.api.response.SolveLessonPuzzleResponse;
 import com.renzzle.backend.domain.puzzle.domain.LessonPuzzle;
 import com.renzzle.backend.domain.puzzle.service.LessonService;
@@ -64,6 +65,13 @@ public class LessonController {
         return ApiUtils.success(SolveLessonPuzzleResponse.builder()
                 .unlockedId(unlockedId)
                 .build());
+    }
+
+    @Operation(summary = "Check lesson progress", description = "Return lesson progress by chapter")
+    @GetMapping("/{chapter}/progress")
+    public ApiResponse<GetLessonProgressResponse> getLessonProgress(@PathVariable("chapter") Integer chapter) {
+        // TODO
+        return ApiUtils.success(null);
     }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/request/AddLessonPuzzleRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/request/AddLessonPuzzleRequest.java
@@ -1,0 +1,39 @@
+package com.renzzle.backend.domain.puzzle.api.request;
+
+import com.renzzle.backend.domain.puzzle.domain.Difficulty;
+import com.renzzle.backend.domain.puzzle.domain.WinColor;
+import com.renzzle.backend.global.validation.ValidBoardString;
+import com.renzzle.backend.global.validation.ValidEnum;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record AddLessonPuzzleRequest(
+        @NotNull(message = "챕터 정보가 없습니다")
+        Integer chapter,
+
+        @NotNull(message = "퍼즐 인덱스 정보가 없습니다")
+        Integer puzzleIndex,
+
+        @NotEmpty(message = "제목 정보가 없습니다")
+        @Size(min = 1, max = 30, message = "제목은 1~30 자리의 문자열이어야 합니다")
+        String title,
+
+        @NotEmpty(message = "보드 정보가 없습니다")
+        @ValidBoardString
+        String boardStatus,
+
+        @Size(max = 1023, message = "설명은 1023자 이하로 작성해야 합니다")
+        String description,
+
+        @NotNull(message = "깊이 정보가 없습니다")
+        Integer depth,
+
+        @NotEmpty(message = "난이도 정보가 없습니다")
+        @ValidEnum(enumClass = Difficulty.DifficultyName.class, message = "잘못된 Difficulty 타입입니다")
+        String difficulty,
+
+        @NotEmpty(message = "승리 색상 정보가 없습니다")
+        @ValidEnum(enumClass = WinColor.WinColorName.class, message = "잘못된 WinColor 타입입니다")
+        String winColor
+) { }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/request/AddLessonPuzzleRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/request/AddLessonPuzzleRequest.java
@@ -12,7 +12,6 @@ public record AddLessonPuzzleRequest(
         @NotNull(message = "챕터 정보가 없습니다")
         Integer chapter,
 
-        @NotNull(message = "퍼즐 인덱스 정보가 없습니다")
         Integer puzzleIndex,
 
         @NotEmpty(message = "제목 정보가 없습니다")

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/request/SolveLessonPuzzleRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/request/SolveLessonPuzzleRequest.java
@@ -1,0 +1,8 @@
+package com.renzzle.backend.domain.puzzle.api.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SolveLessonPuzzleRequest(
+        @NotNull
+        Long puzzleId
+) { }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/response/GetLessonProgressResponse.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/response/GetLessonProgressResponse.java
@@ -1,0 +1,8 @@
+package com.renzzle.backend.domain.puzzle.api.response;
+
+import lombok.Builder;
+
+@Builder
+public record GetLessonProgressResponse(
+        double progress
+) { }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/api/response/SolveLessonPuzzleResponse.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/api/response/SolveLessonPuzzleResponse.java
@@ -1,0 +1,8 @@
+package com.renzzle.backend.domain.puzzle.api.response;
+
+import lombok.Builder;
+
+@Builder
+public record SolveLessonPuzzleResponse(
+        Long unlockedId
+) { }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/dao/LessonPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/dao/LessonPuzzleRepository.java
@@ -2,6 +2,22 @@ package com.renzzle.backend.domain.puzzle.dao;
 
 import com.renzzle.backend.domain.puzzle.domain.LessonPuzzle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface LessonPuzzleRepository extends JpaRepository<LessonPuzzle, Long> {
+
+    @Query(value = "SELECT COALESCE(MAX(lesson_index), -1) FROM lesson_puzzle"
+            , nativeQuery = true)
+    int findTopIndex();
+
+    @Modifying
+    @Transactional
+    @Query(value = "UPDATE lesson_puzzle " +
+            "SET lesson_index = lesson_index + 1 " +
+            "WHERE lesson_index >= :targetIdx"
+            ,nativeQuery = true)
+    void increaseIndexesFrom(int targetIdx);
+
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/dao/LessonPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/dao/LessonPuzzleRepository.java
@@ -8,9 +8,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface LessonPuzzleRepository extends JpaRepository<LessonPuzzle, Long> {
 
-    @Query(value = "SELECT COALESCE(MAX(lesson_index), -1) FROM lesson_puzzle"
+    @Query(value = "SELECT COALESCE(MAX(lesson_index), -1) " +
+            "FROM lesson_puzzle " +
+            "WHERE chapter = :chapter"
             , nativeQuery = true)
-    int findTopIndex();
+    int findTopIndex(int chapter);
 
     @Modifying
     @Transactional

--- a/src/main/java/com/renzzle/backend/domain/puzzle/dao/LessonPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/dao/LessonPuzzleRepository.java
@@ -6,20 +6,27 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 public interface LessonPuzzleRepository extends JpaRepository<LessonPuzzle, Long> {
 
     @Query(value = "SELECT COALESCE(MAX(lesson_index), -1) " +
             "FROM lesson_puzzle " +
-            "WHERE chapter = :chapter"
-            , nativeQuery = true)
+            "WHERE chapter = :chapter",
+            nativeQuery = true)
     int findTopIndex(int chapter);
 
     @Modifying
     @Transactional
     @Query(value = "UPDATE lesson_puzzle " +
             "SET lesson_index = lesson_index + 1 " +
-            "WHERE lesson_index >= :targetIdx AND chapter = :chapter"
-            ,nativeQuery = true)
+            "WHERE lesson_index >= :targetIdx AND chapter = :chapter",
+            nativeQuery = true)
     void increaseIndexesFrom(int chapter, int targetIdx);
+
+    @Query(value = "SELECT * FROM lesson_puzzle " +
+            "WHERE chapter = :chapter AND lesson_index = :index",
+            nativeQuery = true)
+    Optional<LessonPuzzle> findByChapterAndIndex(int chapter, int index);
 
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/dao/LessonPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/dao/LessonPuzzleRepository.java
@@ -18,8 +18,8 @@ public interface LessonPuzzleRepository extends JpaRepository<LessonPuzzle, Long
     @Transactional
     @Query(value = "UPDATE lesson_puzzle " +
             "SET lesson_index = lesson_index + 1 " +
-            "WHERE lesson_index >= :targetIdx"
+            "WHERE lesson_index >= :targetIdx AND chapter = :chapter"
             ,nativeQuery = true)
-    void increaseIndexesFrom(int targetIdx);
+    void increaseIndexesFrom(int chapter, int targetIdx);
 
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/dao/LessonPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/dao/LessonPuzzleRepository.java
@@ -1,0 +1,7 @@
+package com.renzzle.backend.domain.puzzle.dao;
+
+import com.renzzle.backend.domain.puzzle.domain.LessonPuzzle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LessonPuzzleRepository extends JpaRepository<LessonPuzzle, Long> {
+}

--- a/src/main/java/com/renzzle/backend/domain/puzzle/dao/SolvedLessonPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/dao/SolvedLessonPuzzleRepository.java
@@ -2,6 +2,15 @@ package com.renzzle.backend.domain.puzzle.dao;
 
 import com.renzzle.backend.domain.puzzle.domain.SolvedLessonPuzzle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface SolvedLessonPuzzleRepository extends JpaRepository<SolvedLessonPuzzle, Long> {
+
+    @Query(value = "SELECT * FROM solved_lesson_puzzle " +
+            "WHERE user_id = :userId AND lesson_id = :lessonId",
+            nativeQuery = true)
+    Optional<SolvedLessonPuzzle> findByUserIdAndLessonId(Long userId, Long lessonId);
+
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/dao/SolvedLessonPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/dao/SolvedLessonPuzzleRepository.java
@@ -1,0 +1,7 @@
+package com.renzzle.backend.domain.puzzle.dao;
+
+import com.renzzle.backend.domain.puzzle.domain.SolvedLessonPuzzle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SolvedLessonPuzzleRepository extends JpaRepository<SolvedLessonPuzzle, Long> {
+}

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/LessonPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/LessonPuzzle.java
@@ -2,6 +2,7 @@ package com.renzzle.backend.domain.puzzle.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import java.time.Instant;
 
@@ -10,7 +11,12 @@ import java.time.Instant;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder(toBuilder = true)
-@Table(name = "lesson_puzzle")
+@Table(
+        name = "lesson_puzzle",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"chapter, lessonIndex"})
+        }
+)
 public class LessonPuzzle {
 
         @Id
@@ -20,7 +26,7 @@ public class LessonPuzzle {
         @Column(name = "chapter", nullable = false)
         private int chapter;
 
-        @Column(name = "lesson_index", unique = true, nullable = false)
+        @Column(name = "lesson_index", nullable = false)
         private int lessonIndex;
 
         @Column(name = "title", nullable = false, length = 31)
@@ -38,12 +44,13 @@ public class LessonPuzzle {
         @Column(name = "description")
         private String description;
 
+        @CreationTimestamp
+        @Column(name = "created_at", updatable = false, nullable = false)
+        private Instant createdAt;
+
         @UpdateTimestamp
         @Column(name = "updated_at", nullable = false)
         private Instant updatedAt;
-
-        @Column(name = "deleted_at")
-        private Instant deletedAt;
 
         @ManyToOne
         @JoinColumn(name = "difficulty", nullable = false)

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/SolvedLessonPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/SolvedLessonPuzzle.java
@@ -3,6 +3,7 @@ package com.renzzle.backend.domain.puzzle.domain;
 import com.renzzle.backend.domain.user.domain.UserEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import java.time.Instant;
@@ -12,7 +13,12 @@ import java.time.Instant;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder(toBuilder = true)
-@Table(name = "solved_lesson_puzzle")
+@Table(
+        name = "solved_lesson_puzzle",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "lesson_id"})
+        }
+)
 public class SolvedLessonPuzzle {
 
     @Id
@@ -29,7 +35,8 @@ public class SolvedLessonPuzzle {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private LessonPuzzle puzzle;
 
-    @Column(name = "solved_at", nullable = false)
+    @CreationTimestamp
+    @Column(name = "solved_at", updatable = false, nullable = false)
     private Instant solvedAt;
 
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/SolvedLessonPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/SolvedLessonPuzzle.java
@@ -3,10 +3,8 @@ package com.renzzle.backend.domain.puzzle.domain;
 import com.renzzle.backend.domain.user.domain.UserEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
-
 import java.time.Instant;
 
 @Entity

--- a/src/main/java/com/renzzle/backend/domain/puzzle/domain/UserCommunityPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/domain/UserCommunityPuzzle.java
@@ -3,11 +3,8 @@ package com.renzzle.backend.domain.puzzle.domain;
 import com.renzzle.backend.domain.user.domain.UserEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
-
 import java.time.Instant;
 
 @Entity
@@ -15,7 +12,12 @@ import java.time.Instant;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder(toBuilder = true)
-@Table(name = "user_community_puzzle")
+@Table(
+        name = "user_community_puzzle",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "community_id"})
+        }
+)
 public class UserCommunityPuzzle {
 
     @Id

--- a/src/main/java/com/renzzle/backend/domain/puzzle/service/LessonService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/service/LessonService.java
@@ -5,11 +5,17 @@ import com.renzzle.backend.domain.puzzle.dao.LessonPuzzleRepository;
 import com.renzzle.backend.domain.puzzle.dao.SolvedLessonPuzzleRepository;
 import com.renzzle.backend.domain.puzzle.domain.Difficulty;
 import com.renzzle.backend.domain.puzzle.domain.LessonPuzzle;
+import com.renzzle.backend.domain.puzzle.domain.SolvedLessonPuzzle;
 import com.renzzle.backend.domain.puzzle.domain.WinColor;
+import com.renzzle.backend.domain.user.domain.UserEntity;
+import com.renzzle.backend.global.exception.CustomException;
+import com.renzzle.backend.global.exception.ErrorCode;
 import com.renzzle.backend.global.util.BoardUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,10 +28,8 @@ public class LessonService {
     public LessonPuzzle createLessonPuzzle(AddLessonPuzzleRequest request) {
         String boardKey = BoardUtils.makeBoardKey(request.boardStatus());
 
-        int index;
-        if(request.puzzleIndex() == null) {
-            index = lessonPuzzleRepository.findTopIndex(request.chapter()) + 1;
-        } else {
+        int index = lessonPuzzleRepository.findTopIndex(request.chapter()) + 1;
+        if(request.puzzleIndex() != null && index > request.puzzleIndex()) {
             index = request.puzzleIndex();
             lessonPuzzleRepository.increaseIndexesFrom(request.chapter(), index);
         }
@@ -45,8 +49,37 @@ public class LessonService {
         return lessonPuzzleRepository.save(puzzle);
     }
 
+    @Transactional
     public void deleteLessonPuzzle(Long lessonId) {
         lessonPuzzleRepository.deleteById(lessonId);
+    }
+
+    @Transactional
+    public Long solveLessonPuzzle(UserEntity user, Long lessonId) {
+        Optional<SolvedLessonPuzzle> existInfo
+                = solvedLessonPuzzleRepository.findByUserIdAndLessonId(user.getId(), lessonId);
+
+        // solve puzzle again
+        if(existInfo.isPresent()) {
+            return null;
+        }
+
+        LessonPuzzle lessonPuzzle = lessonPuzzleRepository.findById(lessonId).orElseThrow(
+                () -> new CustomException(ErrorCode.CANNOT_FIND_LESSON_PUZZLE)
+        );
+
+        SolvedLessonPuzzle solvedLessonPuzzle = SolvedLessonPuzzle.builder()
+                .user(user)
+                .puzzle(lessonPuzzle)
+                .build();
+        solvedLessonPuzzleRepository.save(solvedLessonPuzzle);
+
+        LessonPuzzle nextPuzzle = lessonPuzzleRepository
+                .findByChapterAndIndex(lessonPuzzle.getChapter(), lessonPuzzle.getLessonIndex() + 1)
+                .orElse(null);
+
+        if(nextPuzzle == null) return null;
+        else return nextPuzzle.getId();
     }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/service/LessonService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/service/LessonService.java
@@ -1,0 +1,15 @@
+package com.renzzle.backend.domain.puzzle.service;
+
+import com.renzzle.backend.domain.puzzle.dao.LessonPuzzleRepository;
+import com.renzzle.backend.domain.puzzle.dao.SolvedLessonPuzzleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LessonService {
+
+    private final LessonPuzzleRepository lessonPuzzleRepository;
+    private final SolvedLessonPuzzleRepository solvedLessonPuzzleRepository;
+
+}

--- a/src/main/java/com/renzzle/backend/domain/puzzle/service/LessonService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/service/LessonService.java
@@ -1,7 +1,12 @@
 package com.renzzle.backend.domain.puzzle.service;
 
+import com.renzzle.backend.domain.puzzle.api.request.AddLessonPuzzleRequest;
 import com.renzzle.backend.domain.puzzle.dao.LessonPuzzleRepository;
 import com.renzzle.backend.domain.puzzle.dao.SolvedLessonPuzzleRepository;
+import com.renzzle.backend.domain.puzzle.domain.Difficulty;
+import com.renzzle.backend.domain.puzzle.domain.LessonPuzzle;
+import com.renzzle.backend.domain.puzzle.domain.WinColor;
+import com.renzzle.backend.global.util.BoardUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,5 +16,31 @@ public class LessonService {
 
     private final LessonPuzzleRepository lessonPuzzleRepository;
     private final SolvedLessonPuzzleRepository solvedLessonPuzzleRepository;
+
+    public LessonPuzzle createLessonPuzzle(AddLessonPuzzleRequest request) {
+        String boardKey = BoardUtils.makeBoardKey(request.boardStatus());
+
+        int index;
+        if(request.puzzleIndex() == null) {
+            index = lessonPuzzleRepository.findTopIndex() + 1;
+        } else {
+            index = request.puzzleIndex();
+            lessonPuzzleRepository.increaseIndexesFrom(index);
+        }
+
+        LessonPuzzle puzzle = LessonPuzzle.builder()
+                .chapter(request.chapter())
+                .lessonIndex(index)
+                .title(request.title())
+                .boardStatus(request.boardStatus())
+                .boardKey(boardKey)
+                .depth(request.depth())
+                .description(request.description())
+                .difficulty(Difficulty.getDifficulty(request.difficulty()))
+                .winColor(WinColor.getWinColor(request.winColor()))
+                .build();
+
+        return lessonPuzzleRepository.save(puzzle);
+    }
 
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/service/LessonService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/service/LessonService.java
@@ -82,4 +82,10 @@ public class LessonService {
         else return nextPuzzle.getId();
     }
 
+    @Transactional(readOnly = true)
+    public double getLessonProgress(UserEntity user, int chapter) {
+        // TODO
+        return 0;
+    }
+
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/service/LessonService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/service/LessonService.java
@@ -22,7 +22,7 @@ public class LessonService {
 
         int index;
         if(request.puzzleIndex() == null) {
-            index = lessonPuzzleRepository.findTopIndex() + 1;
+            index = lessonPuzzleRepository.findTopIndex(request.chapter()) + 1;
         } else {
             index = request.puzzleIndex();
             lessonPuzzleRepository.increaseIndexesFrom(index);

--- a/src/main/java/com/renzzle/backend/domain/puzzle/service/LessonService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/service/LessonService.java
@@ -25,7 +25,7 @@ public class LessonService {
             index = lessonPuzzleRepository.findTopIndex(request.chapter()) + 1;
         } else {
             index = request.puzzleIndex();
-            lessonPuzzleRepository.increaseIndexesFrom(index);
+            lessonPuzzleRepository.increaseIndexesFrom(request.chapter(), index);
         }
 
         LessonPuzzle puzzle = LessonPuzzle.builder()

--- a/src/main/java/com/renzzle/backend/domain/puzzle/service/LessonService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/service/LessonService.java
@@ -9,6 +9,7 @@ import com.renzzle.backend.domain.puzzle.domain.WinColor;
 import com.renzzle.backend.global.util.BoardUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +18,7 @@ public class LessonService {
     private final LessonPuzzleRepository lessonPuzzleRepository;
     private final SolvedLessonPuzzleRepository solvedLessonPuzzleRepository;
 
+    @Transactional
     public LessonPuzzle createLessonPuzzle(AddLessonPuzzleRequest request) {
         String boardKey = BoardUtils.makeBoardKey(request.boardStatus());
 
@@ -41,6 +43,10 @@ public class LessonService {
                 .build();
 
         return lessonPuzzleRepository.save(puzzle);
+    }
+
+    public void deleteLessonPuzzle(Long lessonId) {
+        lessonPuzzleRepository.deleteById(lessonId);
     }
 
 }

--- a/src/main/java/com/renzzle/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/renzzle/backend/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.renzzle.backend.global.config;
 import com.renzzle.backend.domain.auth.dao.AdminRepository;
 import com.renzzle.backend.domain.auth.service.JwtProvider;
 import com.renzzle.backend.domain.user.dao.UserRepository;
+import com.renzzle.backend.global.security.CustomAccessDeniedHandler;
 import com.renzzle.backend.global.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -30,6 +31,7 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
     private final AdminRepository adminRepository;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
@@ -52,10 +54,12 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(request -> request
                         .requestMatchers(permitAllRequestMatchers.toArray(new RequestMatcher[0])).permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/lesson").hasRole(ADMIN)
-                        .requestMatchers(HttpMethod.DELETE, "/api/lesson/**").hasRole(ADMIN)
+                        .requestMatchers(HttpMethod.POST, "/api/lesson").hasAuthority(ADMIN)
+                        .requestMatchers(HttpMethod.DELETE, "/api/lesson/**").hasAuthority(ADMIN)
                         .anyRequest().authenticated()
                 )
+                .exceptionHandling(exceptionHandling ->
+                        exceptionHandling.accessDeniedHandler(accessDeniedHandler))
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, userRepository, adminRepository, permitAllRequestMatchers), UsernamePasswordAuthenticationFilter.class)
                 .build();
     }

--- a/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     INVALID_EMAIL(HttpStatus.UNAUTHORIZED, "A4012", "유효하지 않은 이메일입니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "A4013", "유효하지 않은 비밀번호입니다."),
     NOT_BEARER_GRANT_TYPE(HttpStatus.UNAUTHORIZED, "A4014", "인증 타입이 Bearer 타입이 아닙니다."),
+    ADMIN_ACCESS_DENIED(HttpStatus.FORBIDDEN, "A403", "관리자 권한이 없습니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "A4090", "이미 존재하는 이메일입니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "A4091", "이미 존재하는 닉네임입니다."),
 

--- a/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
@@ -35,8 +35,9 @@ public enum ErrorCode {
     ILLEGAL_TOKEN(HttpStatus.UNAUTHORIZED, "J4013", "토큰이 없거나 잘못된 형식의 토큰입니다."),
     CANNOT_PARSE_TOKEN(HttpStatus.UNAUTHORIZED, "J4014", "토큰 파싱에 실패하였습니다."),
 
-    // Community Puzzle
-    CANNOT_FIND_COMMUNITY_PUZZLE(HttpStatus.NOT_FOUND, "P404", "해당하는 커뮤니티 퍼즐을 찾을 수 없습니다.")
+    // Puzzle
+    CANNOT_FIND_COMMUNITY_PUZZLE(HttpStatus.NOT_FOUND, "P4040", "해당하는 커뮤니티 퍼즐을 찾을 수 없습니다."),
+    CANNOT_FIND_LESSON_PUZZLE(HttpStatus.NOT_FOUND, "P4041", "해당하는 레슨 퍼즐을 찾을 수 없습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/renzzle/backend/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/renzzle/backend/global/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,36 @@
+package com.renzzle.backend.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.renzzle.backend.global.common.response.ApiResponse;
+import com.renzzle.backend.global.exception.ErrorCode;
+import com.renzzle.backend.global.exception.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        ErrorCode errorCode = ErrorCode.ADMIN_ACCESS_DENIED;
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        try {
+            ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+            ApiResponse<Object> objectApiResponse = ApiResponse.create(false, null, errorResponse);
+            String responseBody = new ObjectMapper().writeValueAsString(objectApiResponse);
+            response.getWriter().write(responseBody);
+        } catch(Exception e) {
+            log.error(e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/renzzle/backend/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/renzzle/backend/global/security/JwtAuthenticationFilter.java
@@ -67,11 +67,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if(user.isEmpty())
             throw new CustomException(ErrorCode.GLOBAL_NOT_FOUND);
 
-        List<String> roles = new ArrayList<>();
+        List<String> authorities = new ArrayList<>();
         if(adminRepository.existsByUser(user.get()))
-            roles.add(ADMIN);
+            authorities.add(ADMIN);
 
-        return new UserDetailsImpl(user.get(), user.get().getPassword(), roles);
+        return new UserDetailsImpl(user.get(), user.get().getPassword(), authorities);
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/src/main/java/com/renzzle/backend/global/security/UserDetailsImpl.java
+++ b/src/main/java/com/renzzle/backend/global/security/UserDetailsImpl.java
@@ -14,20 +14,20 @@ public class UserDetailsImpl implements UserDetails {
     @Getter
     private final UserEntity user;
     private final String password;
-    private final List<String> roles;
+    private final List<String> authorities;
 
-    public UserDetailsImpl(UserEntity user, String password, List<String> roles) {
+    public UserDetailsImpl(UserEntity user, String password, List<String> authorities) {
         this.user = user;
         this.password = password;
-        this.roles = roles;
+        this.authorities = authorities;
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        if (this.roles == null) {
+        if (this.authorities == null) {
             return Collections.emptyList();
         }
-        return this.roles.stream()
+        return this.authorities.stream()
                 .map(SimpleGrantedAuthority::new)
                 .toList();
     }


### PR DESCRIPTION
### ✏️ 작업 개요
레슨 퍼즐 API 작업중

### 🔨 작업 상세 내용
1. 레슨 퍼즐 인덱스 로직 구현 (챕터, 인덱스 복합 유니크로 설정)
2. 관리자 권한 구현 (레슨 문제 등록 및 삭제 API 관련)
3. solve lesson puzzle API 구현 (챕터마다 첫 레슨 문제 잠금은 해제하는 방식) 

### 💡 생각해볼 문제
- 레슨 퍼즐 인덱스 관련 현재는 챕터별로 인덱스가 따로 구현되고 인덱스를 따로 설정하지 않고 insert 하면 자동으로 가장 마지막 인덱스가 부여됨. 마지막 인덱스보다 훨씬 큰 인덱스를 부여할 경우도 자동으로 가장 마지막 인덱스가 부여됨 (ex - 0, 1, 2가 존재할 경우 10을 삽입해도 3번 인덱스가 부여)
- 관리자 권한을 가지는 유저 따로 생성. 이 권한을 가지면 레슨 문제 편집 권한을 가짐. 추후 다른 관리자 API 추가 시 용이.
