### PR TITLE
CI 환경변수 인식 오류 해결

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,9 @@ jobs:
           echo "GMAIL_ADDRESS=\"${{ secrets.GMAIL_ADDRESS }}\"" >> .env
           echo "JWT_SECRET_KEY=\"${{ secrets.JWT_SECRET_KEY }}\"" >> .env
 
+      - name: Load Environment Variables
+        run: export $(cat .env | xargs)
+
       - name: Start Docker Compose with .env
         run: docker compose --env-file .env up -d
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,25 +40,12 @@ jobs:
       - name: Start Docker Compose with .env
         run: docker compose --env-file .env up -d
 
-#      - name: Start Docker Compose
-#        run: docker compose up -d
-
       # Redis Health Check
       - name: Redis Health Check
         run: docker exec -i redis redis-cli -a $REDIS_PASSWORD ping
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
-
-#      - name: Cache Gradle packages
-#        uses: actions/cache@v3
-#        with:
-#          path: |
-#            ~/.gradle/caches
-#            ~/.gradle/wrapper
-#          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-#          restore-keys: |
-#            ${{ runner.os }}-gradle-
 
       - name: Verify Environment Variables Before Build
         run: |
@@ -70,14 +57,6 @@ jobs:
           echo "JWT_SECRET_KEY = (hidden)"
 
       - name: Build and Test with Gradle
-#        env:
-#          DB_ADDRESS: ${{ secrets.DB_ADDRESS }}
-#          DB_USER: ${{ secrets.DB_USER }}
-#          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-#          REDIS_PASSWORD: ${{ secrets.TEST_REDIS_PASSWORD }}
-#          GMAIL_ADDRESS: ${{ secrets.GMAIL_ADDRESS }}
-#          GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
-#          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
         run: ./gradlew build
 
       - name: Test build success

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,19 +57,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-
-
       - name: Build and Test with Gradle
         env:
-#          SPRING_DATASOURCE_URL: jdbc:mysql://${{ secrets.DB_ADDRESS }}
-#          SPRING_DATASOURCE_USERNAME: ${{ secrets.DB_USER }}
-#          SPRING_DATASOURCE_PASSWORD: ${{ secrets.DB_PASSWORD }}
-#          SPRING_DATA_REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
-#          SPRING_JWT_SECRET: ${{ secrets.JWT_SECRET_KEY }}
-#          SPRING_MAIL_USERNAME: ${{ secrets.GMAIL_ADDRESS }}
-#          SPRING_MAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
-          SPRING_PROFILES_ACTIVE: test
-        run: ./gradlew clean build --stacktrace
+          DB_ADDRESS: ${{ secrets.DB_ADDRESS }}
+          DB_USER: ${{ secrets.DB_USER }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          REDIS_PASSWORD: ${{ secrets.TEST_REDIS_PASSWORD }}
+          GMAIL_ADDRESS: ${{ secrets.GMAIL_ADDRESS }}
+          GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+        run: ./gradlew clean build
 
       - name: Test build success
         run: echo "Build completed successfully!"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,15 +23,18 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Set Environment Variables
+      - name: Create .env file
         run: |
-          export DB_ADDRESS=${{ secrets.DB_ADDRESS }}
-          export DB_USER=${{ secrets.DB_USER }}
-          export DB_PASSWORD=${{ secrets.DB_PASSWORD }}
-          export REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}
-          export GMAIL_ADDRESS=${{ secrets.GMAIL_ADDRESS }}
-          export GMAIL_PASSWORD=${{ secrets.GMAIL_PASSWORD }}
-          export JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
+          echo "DB_ADDRESS=${{ secrets.DB_ADDRESS }}" >> .env
+          echo "DB_USER=${{ secrets.DB_USER }}" >> .env
+          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+          echo "REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}" >> .env
+          echo "GMAIL_PASSWORD=${{ secrets.GMAIL_PASSWORD }}" >> .env
+          echo "GMAIL_ADDRESS=\"${{ secrets.GMAIL_ADDRESS }}\"" >> .env
+          echo "JWT_SECRET_KEY=\"${{ secrets.JWT_SECRET_KEY }}\"" >> .env
+
+      - name: Start Docker Compose with .env
+        run: docker compose --env-file .env up -d
 
       - name: Start Docker Compose
         run: docker compose up -d
@@ -56,6 +59,14 @@ jobs:
 
 
       - name: Build and Test with Gradle
+        env:
+          SPRING_DATASOURCE_URL: jdbc:mysql://${{ secrets.DB_ADDRESS }}
+          SPRING_DATASOURCE_USERNAME: ${{ secrets.DB_USER }}
+          SPRING_DATASOURCE_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          SPRING_DATA_REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          SPRING_JWT_SECRET: ${{ secrets.JWT_SECRET_KEY }}
+          SPRING_MAIL_USERNAME: ${{ secrets.GMAIL_ADDRESS }}
+          SPRING_MAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
         run: ./gradlew build --stacktrace
 
       - name: Test build success

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,17 +33,8 @@ jobs:
           export GMAIL_PASSWORD=${{ secrets.GMAIL_PASSWORD }}
           export JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
 
-#      - name: Load Environment Variables
-#        run: export $(cat .env | xargs)
-
-#      - name: Start Docker Compose
-#        run: docker compose up -d
-#
-#      - name: Check Running Containers
-#        run: docker ps -a
-
-      - name: Check Redis Logs
-        run: docker logs redis
+      - name: Start Docker Compose
+        run: docker compose up -d
 
       # Redis Health Check
       - name: Redis Health Check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,11 +23,21 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Load Environment Variables
-        run: export $(cat .env | xargs)
+      - name: Set Environment Variables
+        run: |
+          export DB_ADDRESS=${{ secrets.DB_ADDRESS }}
+          export DB_USER=${{ secrets.DB_USER }}
+          export DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+          export REDIS_PASSWORD=${{ secrets.TEST_REDIS_PASSWORD }}
+          export GMAIL_ADDRESS=${{ secrets.GMAIL_ADDRESS }}
+          export GMAIL_PASSWORD=${{ secrets.GMAIL_PASSWORD }}
+          export JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
 
-      - name: Start Docker Compose with .env
-        run: docker compose --env-file .env up -d
+#      - name: Load Environment Variables
+#        run: export $(cat .env | xargs)
+
+      - name: Start Docker Compose
+        run: docker-compose up -d
 
       # Redis Health Check
       - name: Redis Health Check
@@ -46,15 +56,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Set Environment Variables
-        run: |
-          export DB_ADDRESS=${{ secrets.DB_ADDRESS }}
-          export DB_USER=${{ secrets.DB_USER }}
-          export DB_PASSWORD=${{ secrets.DB_PASSWORD }}
-          export REDIS_PASSWORD=${{ secrets.TEST_REDIS_PASSWORD }}
-          export GMAIL_ADDRESS=${{ secrets.GMAIL_ADDRESS }}
-          export GMAIL_PASSWORD=${{ secrets.GMAIL_PASSWORD }}
-          export JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
+
 
       - name: Build and Test with Gradle
         run: ./gradlew build --stacktrace

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,7 +66,7 @@ jobs:
           GMAIL_ADDRESS: ${{ secrets.GMAIL_ADDRESS }}
           GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
           JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
-        run: ./gradlew clean build
+        run: ./gradlew build --scan
 
       - name: Test build success
         run: echo "Build completed successfully!"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,15 +29,15 @@ jobs:
 #          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
 #        run: docker compose up -d
 
-      - name: Create .env file
-        run: |
-          echo "DB_ADDRESS=${{ secrets.DB_ADDRESS }}" >> .env
-          echo "DB_USER=${{ secrets.DB_USER }}" >> .env
-          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
-          echo "REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}" >> .env
-          echo "GMAIL_PASSWORD=${{ secrets.GMAIL_PASSWORD }}" >> .env
-          echo "GMAIL_ADDRESS=\"${{ secrets.GMAIL_ADDRESS }}\"" >> .env
-          echo "JWT_SECRET_KEY=\"${{ secrets.JWT_SECRET_KEY }}\"" >> .env
+#      - name: Create .env file
+#        run: |
+#          echo "DB_ADDRESS=${{ secrets.DB_ADDRESS }}" >> .env
+#          echo "DB_USER=${{ secrets.DB_USER }}" >> .env
+#          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+#          echo "REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}" >> .env
+#          echo "GMAIL_PASSWORD=${{ secrets.GMAIL_PASSWORD }}" >> .env
+#          echo "GMAIL_ADDRESS=\"${{ secrets.GMAIL_ADDRESS }}\"" >> .env
+#          echo "JWT_SECRET_KEY=\"${{ secrets.JWT_SECRET_KEY }}\"" >> .env
 
       - name: Load Environment Variables
         run: export $(cat .env | xargs)
@@ -62,15 +62,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: Set Environment Variables
+        run: |
+          export DB_ADDRESS=${{ secrets.DB_ADDRESS }}
+          export DB_USER=${{ secrets.DB_USER }}
+          export DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+          export REDIS_PASSWORD=${{ secrets.TEST_REDIS_PASSWORD }}
+          export GMAIL_ADDRESS=${{ secrets.GMAIL_ADDRESS }}
+          export GMAIL_PASSWORD=${{ secrets.GMAIL_PASSWORD }}
+          export JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
+
       - name: Build and Test with Gradle
-        env:
-          DB_ADDRESS: ${{ secrets.DB_ADDRESS }}
-          DB_USER: ${{ secrets.DB_USER }}
-          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          REDIS_PASSWORD: ${{ secrets.TEST_REDIS_PASSWORD }}
-          GMAIL_ADDRESS: ${{ secrets.GMAIL_ADDRESS }}
-          GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
-          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
         run: ./gradlew build --stacktrace
 
       - name: Test build success

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
 #        run: export $(cat .env | xargs)
 
       - name: Start Docker Compose
-        run: docker-compose up -d
+        run: docker compose up -d
 
       # Redis Health Check
       - name: Redis Health Check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,11 +23,24 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      # Docker Compose 실행 (Redis 포함)
-      - name: Start Docker Compose
-        env:
-          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
-        run: docker compose up -d
+#      # Docker Compose 실행 (Redis 포함)
+#      - name: Start Docker Compose
+#        env:
+#          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+#        run: docker compose up -d
+
+      - name: Create .env file
+        run: |
+          echo "DB_ADDRESS=${{ secrets.DB_ADDRESS }}" >> .env
+          echo "DB_USER=${{ secrets.DB_USER }}" >> .env
+          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+          echo "REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}" >> .env
+          echo "GMAIL_PASSWORD=${{ secrets.GMAIL_PASSWORD }}" >> .env
+          echo "GMAIL_ADDRESS=\"${{ secrets.GMAIL_ADDRESS }}\"" >> .env
+          echo "JWT_SECRET_KEY=\"${{ secrets.JWT_SECRET_KEY }}\"" >> .env
+
+      - name: Start Docker Compose with .env
+        run: docker compose --env-file .env up -d
 
       # Redis Health Check
       - name: Redis Health Check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,8 +3,6 @@ name: Java CI with Gradle
 on:
   pull_request:
     branches: [ "main"]
-  push:
-    branches: [ "main", "fix/CICD"]
 
 permissions:
   write-all

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
           export DB_ADDRESS=${{ secrets.DB_ADDRESS }}
           export DB_USER=${{ secrets.DB_USER }}
           export DB_PASSWORD=${{ secrets.DB_PASSWORD }}
-          export REDIS_PASSWORD=${{ secrets.TEST_REDIS_PASSWORD }}
+          export REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}
           export GMAIL_ADDRESS=${{ secrets.GMAIL_ADDRESS }}
           export GMAIL_PASSWORD=${{ secrets.GMAIL_PASSWORD }}
           export JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
@@ -36,8 +36,14 @@ jobs:
 #      - name: Load Environment Variables
 #        run: export $(cat .env | xargs)
 
-      - name: Start Docker Compose
-        run: docker compose up -d
+#      - name: Start Docker Compose
+#        run: docker compose up -d
+#
+#      - name: Check Running Containers
+#        run: docker ps -a
+
+      - name: Check Redis Logs
+        run: docker logs redis
 
       # Redis Health Check
       - name: Redis Health Check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,6 +33,7 @@ jobs:
           echo "GMAIL_ADDRESS=\"${{ secrets.GMAIL_ADDRESS }}\"" >> .env
           echo "JWT_SECRET_KEY=\"${{ secrets.JWT_SECRET_KEY }}\"" >> .env
 
+
       - name: Start Docker Compose with .env
         run: docker compose --env-file .env up -d
 
@@ -60,13 +61,14 @@ jobs:
 
       - name: Build and Test with Gradle
         env:
-          SPRING_DATASOURCE_URL: jdbc:mysql://${{ secrets.DB_ADDRESS }}
-          SPRING_DATASOURCE_USERNAME: ${{ secrets.DB_USER }}
-          SPRING_DATASOURCE_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          SPRING_DATA_REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
-          SPRING_JWT_SECRET: ${{ secrets.JWT_SECRET_KEY }}
-          SPRING_MAIL_USERNAME: ${{ secrets.GMAIL_ADDRESS }}
-          SPRING_MAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
+#          SPRING_DATASOURCE_URL: jdbc:mysql://${{ secrets.DB_ADDRESS }}
+#          SPRING_DATASOURCE_USERNAME: ${{ secrets.DB_USER }}
+#          SPRING_DATASOURCE_PASSWORD: ${{ secrets.DB_PASSWORD }}
+#          SPRING_DATA_REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+#          SPRING_JWT_SECRET: ${{ secrets.JWT_SECRET_KEY }}
+#          SPRING_MAIL_USERNAME: ${{ secrets.GMAIL_ADDRESS }}
+#          SPRING_MAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
+          SPRING_PROFILES_ACTIVE: test
         run: ./gradlew build --stacktrace
 
       - name: Test build success

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,75 +1,61 @@
-  name: Java CI with Gradle
+name: Java CI with Gradle
 
-  on:
-    pull_request:
-      branches: [ "main"]
-    push:
-      branches: [ "main", "fix/CD", "feat/userapi"]
+on:
+  pull_request:
+    branches: [ "main"]
+  push:
+    branches: [ "main", "fix/CICD"]
 
-  permissions:
-    write-all
+permissions:
+  write-all
 
-  jobs:
-    build:
-      runs-on: ubuntu-latest
+jobs:
+  build:
+    runs-on: ubuntu-latest
 
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v3
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-        - name: Set up JDK 17
-          uses: actions/setup-java@v3
-          with:
-            java-version: '17'
-            distribution: 'temurin'
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-        # Setup Redis
-        - name: Setup Redis
-          uses: shogo82148/actions-setup-redis@v1.30.1
-          with:
-            redis-version: 6.2.0
-            redis-port: 6379
-            auto-start: true
-            redis-password: 12345678
-        # Redis Health Check
-        - name: Redis Health Check
-          run: redis-cli -h 127.0.0.1 -p 6379 -a 12345678 ping
+      # Docker Compose 실행 (Redis 포함)
+      - name: Start Docker Compose
+        env:
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+        run: docker compose up -d
 
-        - name: Grant execute permission for gradlew
-          run: chmod +x ./gradlew
+      # Redis Health Check
+      - name: Redis Health Check
+        run: docker exec -i redis redis-cli -a $REDIS_PASSWORD ping
 
-        - name: Cache Gradle packages
-          uses: actions/cache@v3
-          with:
-            path: |
-              ~/.gradle/caches
-              ~/.gradle/wrapper
-            key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-            restore-keys: |
-              ${{ runner.os }}-gradle-
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
 
-        - name: Run Tests with Gradle
-          env:
-            DB_ADDRESS: ${{ secrets.DB_ADDRESS }}
-            DB_USER: ${{ secrets.DB_USER }}
-            DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-            REDIS_PASSWORD: ${{ secrets.TEST_REDIS_PASSWORD }}
-            GMAIL_ADDRESS: ${{ secrets.GMAIL_ADDRESS }}
-            GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
-            JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
-          run: |
-            ./gradlew test --stacktrace
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
-        - name: Build and Test with Gradle
-          env:
-            DB_ADDRESS: ${{ secrets.DB_ADDRESS }}
-            DB_USER: ${{ secrets.DB_USER }}
-            DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-            REDIS_PASSWORD: ${{ secrets.TEST_REDIS_PASSWORD }}
-            GMAIL_ADDRESS: ${{ secrets.GMAIL_ADDRESS }}
-            GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
-            JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
-          run: ./gradlew build -x test --stacktrace
+      - name: Build and Test with Gradle
+        env:
+          DB_ADDRESS: ${{ secrets.DB_ADDRESS }}
+          DB_USER: ${{ secrets.DB_USER }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          REDIS_PASSWORD: ${{ secrets.TEST_REDIS_PASSWORD }}
+          GMAIL_ADDRESS: ${{ secrets.GMAIL_ADDRESS }}
+          GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+        run: ./gradlew build --stacktrace
 
-        - name: Test build success
-          run: echo "Build completed successfully!"
+      - name: Test build success
+        run: echo "Build completed successfully!"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -69,7 +69,7 @@ jobs:
 #          SPRING_MAIL_USERNAME: ${{ secrets.GMAIL_ADDRESS }}
 #          SPRING_MAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
           SPRING_PROFILES_ACTIVE: test
-        run: ./gradlew build --stacktrace
+        run: ./gradlew clean build --stacktrace
 
       - name: Test build success
         run: echo "Build completed successfully!"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,22 +23,6 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-#      # Docker Compose 실행 (Redis 포함)
-#      - name: Start Docker Compose
-#        env:
-#          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
-#        run: docker compose up -d
-
-#      - name: Create .env file
-#        run: |
-#          echo "DB_ADDRESS=${{ secrets.DB_ADDRESS }}" >> .env
-#          echo "DB_USER=${{ secrets.DB_USER }}" >> .env
-#          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
-#          echo "REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}" >> .env
-#          echo "GMAIL_PASSWORD=${{ secrets.GMAIL_PASSWORD }}" >> .env
-#          echo "GMAIL_ADDRESS=\"${{ secrets.GMAIL_ADDRESS }}\"" >> .env
-#          echo "JWT_SECRET_KEY=\"${{ secrets.JWT_SECRET_KEY }}\"" >> .env
-
       - name: Load Environment Variables
         run: export $(cat .env | xargs)
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,12 +33,15 @@ jobs:
           echo "GMAIL_ADDRESS=\"${{ secrets.GMAIL_ADDRESS }}\"" >> .env
           echo "JWT_SECRET_KEY=\"${{ secrets.JWT_SECRET_KEY }}\"" >> .env
 
+      - name: Load environment variables from .env
+        run: cat .env >> $GITHUB_ENV
+
 
       - name: Start Docker Compose with .env
         run: docker compose --env-file .env up -d
 
-      - name: Start Docker Compose
-        run: docker compose up -d
+#      - name: Start Docker Compose
+#        run: docker compose up -d
 
       # Redis Health Check
       - name: Redis Health Check
@@ -47,26 +50,35 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+#      - name: Cache Gradle packages
+#        uses: actions/cache@v3
+#        with:
+#          path: |
+#            ~/.gradle/caches
+#            ~/.gradle/wrapper
+#          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+#          restore-keys: |
+#            ${{ runner.os }}-gradle-
+
+      - name: Verify Environment Variables Before Build
+        run: |
+          echo "DB_ADDRESS = $DB_ADDRESS"
+          echo "DB_USER = $DB_USER"
+          echo "DB_PASSWORD = (hidden)"
+          echo "REDIS_PASSWORD = (hidden)"
+          echo "GMAIL_ADDRESS = $GMAIL_ADDRESS"
+          echo "JWT_SECRET_KEY = (hidden)"
 
       - name: Build and Test with Gradle
-        env:
-          DB_ADDRESS: ${{ secrets.DB_ADDRESS }}
-          DB_USER: ${{ secrets.DB_USER }}
-          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          REDIS_PASSWORD: ${{ secrets.TEST_REDIS_PASSWORD }}
-          GMAIL_ADDRESS: ${{ secrets.GMAIL_ADDRESS }}
-          GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
-          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
-        run: ./gradlew build --scan
+#        env:
+#          DB_ADDRESS: ${{ secrets.DB_ADDRESS }}
+#          DB_USER: ${{ secrets.DB_USER }}
+#          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+#          REDIS_PASSWORD: ${{ secrets.TEST_REDIS_PASSWORD }}
+#          GMAIL_ADDRESS: ${{ secrets.GMAIL_ADDRESS }}
+#          GMAIL_PASSWORD: ${{ secrets.GMAIL_PASSWORD }}
+#          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+        run: ./gradlew build
 
       - name: Test build success
         run: echo "Build completed successfully!"

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+src/test/resources/application-test.yml
 
 ### NetBeans ###
 /nbproject/private/

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,11 @@ repositories {
 	mavenCentral()
 }
 
+//test {
+//	systemProperty "spring.profiles.active", "test"
+//	useJUnitPlatform()
+//}
+
 dependencies {
 	// REST
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -57,6 +62,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
-tasks.named('test') {
+tasks.named('test', Test){
 	useJUnitPlatform()
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     networks:
       - app-network
     command: redis-server --requirepass ${REDIS_PASSWORD}
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
 
 networks:
   app-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     image: renzzle/github-action:latest
     ports:
       - "9001:9001"
+    env_file:
+      - .env
     environment:
       - REDIS_PASSWORD=${REDIS_PASSWORD}
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,8 @@
-version: '3.8'
-
 services:
   app:
     image: renzzle/github-action:latest
     ports:
       - "9001:9001"
-    env_file:
-      - .env
     environment:
       - REDIS_PASSWORD=${REDIS_PASSWORD}
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - redis
 
   redis:
+    container_name: redis
     image: redis:7.0.12
     ports:
       - "6379:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
     image: renzzle/github-action:latest
     ports:
       - "9001:9001"
-    env_file:
-      - .env
+#    env_file:
+#      - .env
     environment:
       - REDIS_PASSWORD=${REDIS_PASSWORD}
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - "9001:9001"
     env_file:
       - .env
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
     networks:
       - app-network
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
     image: renzzle/github-action:latest
     ports:
       - "9001:9001"
-#    env_file:
-#      - .env
+    env_file:
+      - .env
     environment:
       - REDIS_PASSWORD=${REDIS_PASSWORD}
     networks:

--- a/src/main/java/com/renzzle/backend/BackendApplication.java
+++ b/src/main/java/com/renzzle/backend/BackendApplication.java
@@ -9,5 +9,4 @@ public class BackendApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(BackendApplication.class, args);
 	}
-
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,7 @@ server:
   port: 9001
 
 spring:
+
   datasource:
     url: jdbc:mysql://${DB_ADDRESS}
     username: ${DB_USER}
@@ -45,6 +46,9 @@ spring:
           timeout: 5000
           starttls:
             enable: true
+  config:
+    activate:
+      on-profile: default
 
 springdoc:
   packages-to-scan: com.renzzle.backend
@@ -55,8 +59,4 @@ springdoc:
     disable-swagger-default-url: true
     display-request-duration: true
     operations-sorter: alpha
-#
-#logging:
-#  level:
-#    root: DEBUG
 

--- a/src/test/java/com/renzzle/backend/auth/JwtTest.java
+++ b/src/test/java/com/renzzle/backend/auth/JwtTest.java
@@ -5,8 +5,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
+//@ActiveProfiles("test")
 public class JwtTest {
 
     @Autowired

--- a/src/test/java/com/renzzle/backend/auth/JwtTest.java
+++ b/src/test/java/com/renzzle/backend/auth/JwtTest.java
@@ -5,11 +5,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
-//@ActiveProfiles("test")
 public class JwtTest {
 
     @Autowired

--- a/src/test/java/com/renzzle/backend/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/renzzle/backend/domain/user/api/UserControllerTest.java
@@ -12,8 +12,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -24,7 +22,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @WebMvcTest(UserController.class)
-//@ActiveProfiles("test")
 class UserControllerTest {
 
     @Autowired

--- a/src/test/java/com/renzzle/backend/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/renzzle/backend/domain/user/api/UserControllerTest.java
@@ -4,7 +4,6 @@ import com.renzzle.backend.domain.user.api.response.UserResponse;
 import com.renzzle.backend.domain.user.domain.UserEntity;
 import com.renzzle.backend.domain.user.service.UserService;
 import com.renzzle.backend.global.security.UserDetailsImpl;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,8 +11,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -23,8 +23,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-
 @WebMvcTest(UserController.class)
+//@ActiveProfiles("test")
 class UserControllerTest {
 
     @Autowired

--- a/src/test/java/com/renzzle/backend/test/DBTest.java
+++ b/src/test/java/com/renzzle/backend/test/DBTest.java
@@ -8,12 +8,19 @@ import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
 import java.util.Optional;
 
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
+//@ActiveProfiles("test")
 public class DBTest {
 
     @Autowired

--- a/src/test/java/com/renzzle/backend/test/DBTest.java
+++ b/src/test/java/com/renzzle/backend/test/DBTest.java
@@ -6,21 +6,17 @@ import com.renzzle.backend.domain.test.domain.JdbcEntity;
 import com.renzzle.backend.domain.test.domain.TestEntity;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Optional;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
-//@ActiveProfiles("test")
 public class DBTest {
 
     @Autowired


### PR DESCRIPTION
### ✏️ 작업 개요
CI 에서 env 파일을 인식하지 못하여 발생하는 테스트 오류를 해결하였습니다.
### 🔨 작업 상세 내용
$GITHUB_ENV 에 환경변수를 주입하여 전역 변수로 지정하여 문제를 해결하였습니다.

### 💡 생각해볼 문제
.env 파일이 왜 test 시에는 전달되지 않는지, 그리고 $GITHUB_ENV의 전역은 어디까지를 의미하는지 알아 볼 필요가 있습니다.
