### PR TITLE
Repository 테스트용 어노테이션 추가

### DIFF
--- a/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
@@ -3,24 +3,17 @@ package com.renzzle.backend.domain.auth.service;
 import com.renzzle.backend.domain.auth.api.request.LoginRequest;
 import com.renzzle.backend.domain.auth.api.request.SignupRequest;
 import com.renzzle.backend.domain.auth.api.response.LoginResponse;
-import com.renzzle.backend.domain.auth.dao.RefreshTokenRedisRepository;
-import com.renzzle.backend.domain.auth.domain.GrantType;
-import com.renzzle.backend.domain.auth.domain.RefreshTokenEntity;
 import com.renzzle.backend.domain.user.dao.UserRepository;
 import com.renzzle.backend.domain.user.domain.UserEntity;
 import com.renzzle.backend.global.exception.CustomException;
 import com.renzzle.backend.global.exception.ErrorCode;
-import com.renzzle.backend.global.util.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import java.time.Duration;
-import java.time.Instant;
+
 import java.util.Optional;
-import static com.renzzle.backend.domain.auth.service.JwtProvider.ACCESS_TOKEN_VALID_MINUTE;
-import static com.renzzle.backend.domain.auth.service.JwtProvider.REFRESH_TOKEN_VALID_MINUTE;
 
 @Service
 @RequiredArgsConstructor
@@ -41,7 +34,7 @@ public class AccountService {
     }
 
     @Transactional(readOnly = true)
-    private boolean isDuplicateSignUp(String deviceId) {
+    public boolean isDuplicateSignUp(String deviceId) {
         return userRepository.existsByDeviceId(deviceId);
     }
 

--- a/src/main/java/com/renzzle/backend/domain/auth/service/EmailService.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/EmailService.java
@@ -115,6 +115,7 @@ public class EmailService {
         emailRepository.save(result);
     }
 
+    @Transactional(readOnly = true)
     public ConfirmCodeResponse confirmCode(ConfirmCodeRequest request) {
         boolean isCorrect = verifyCode(request.email(), request.code());
         if(!isCorrect) throw new CustomException(ErrorCode.INVALID_EMAIL_AUTH_CODE);
@@ -127,7 +128,6 @@ public class EmailService {
                 .build();
     }
 
-    @Transactional(readOnly = true)
     private boolean verifyCode(String address, String code) {
         Optional<AuthEmailEntity> emailEntity = emailRepository.findById(address);
 

--- a/src/test/java/com/renzzle/backend/config/DataJpaTestWithInitContainers.java
+++ b/src/test/java/com/renzzle/backend/config/DataJpaTestWithInitContainers.java
@@ -1,0 +1,22 @@
+package com.renzzle.backend.config;
+
+import com.renzzle.backend.global.init.DataInitializer;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@DataJpaTest
+@Import(DataInitializer.class)
+@ImportAutoConfiguration(JdbcTemplateAutoConfiguration.class)
+@ContextConfiguration(initializers = TestContainersConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public @interface DataJpaTestWithInitContainers {
+}

--- a/src/test/java/com/renzzle/backend/config/TestContainersConfig.java
+++ b/src/test/java/com/renzzle/backend/config/TestContainersConfig.java
@@ -37,7 +37,6 @@ public class TestContainersConfig implements ApplicationContextInitializer<Confi
                     "spring.mail.password=" + "password",
                     "rank.session.ttl=" + "10",
                     "REDIS_PASSWORD=" + "376198"
-
             );
         } catch (Exception e) {
             throw new RuntimeException("TestContainers Failed: " + e.getMessage(), e);

--- a/src/test/java/com/renzzle/backend/domain/auth/service/AccountServiceTest.java
+++ b/src/test/java/com/renzzle/backend/domain/auth/service/AccountServiceTest.java
@@ -41,13 +41,13 @@ public class AccountServiceTest {
     private LoginRequest validLoginRequest;
 
     @BeforeEach
-    void setup() {
+    public void setup() {
         validSignupRequest = new SignupRequest(email, password, nickname, authVerityToken, deviceId);
         validLoginRequest = new LoginRequest(email, password);
     }
 
     @Test
-    void signUp_ShouldCreateUserAndReturnTokens_WhenValid() {
+    public void signUp_ShouldCreateUserAndReturnTokens_WhenValid() {
         // given
         when(authService.verifyAuthVerityToken(authVerityToken, email)).thenReturn(true);
         when(userRepository.existsByEmail(email)).thenReturn(false);
@@ -65,7 +65,7 @@ public class AccountServiceTest {
     }
 
     @Test
-    void signUp_ShouldThrowException_WhenEmailAlreadyExists() {
+    public void signUp_ShouldThrowException_WhenEmailAlreadyExists() {
         when(authService.verifyAuthVerityToken(authVerityToken, email)).thenReturn(true);
         when(userRepository.existsByEmail(email)).thenReturn(true);
 
@@ -77,7 +77,7 @@ public class AccountServiceTest {
     }
 
     @Test
-    void signUp_ShouldThrowException_WhenInvalidAuthToken() {
+    public void signUp_ShouldThrowException_WhenInvalidAuthToken() {
         when(authService.verifyAuthVerityToken(authVerityToken, email)).thenReturn(false);
 
         CustomException ex = assertThrows(CustomException.class, () -> {
@@ -88,7 +88,7 @@ public class AccountServiceTest {
     }
 
     @Test
-    void login_ShouldReturnTokens_WhenCredentialsAreValid() {
+    public void login_ShouldReturnTokens_WhenCredentialsAreValid() {
         UserEntity user = UserEntity.builder()
                 .email(email)
                 .password(new BCryptPasswordEncoder().encode(password))
@@ -106,7 +106,7 @@ public class AccountServiceTest {
     }
 
     @Test
-    void login_ShouldThrowException_WhenEmailNotFound() {
+    public void login_ShouldThrowException_WhenEmailNotFound() {
         when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
 
         CustomException ex = assertThrows(CustomException.class, () -> {
@@ -117,7 +117,7 @@ public class AccountServiceTest {
     }
 
     @Test
-    void login_ShouldThrowException_WhenPasswordMismatch() {
+    public void login_ShouldThrowException_WhenPasswordMismatch() {
         UserEntity user = UserEntity.builder()
                 .email(email)
                 .password(new BCryptPasswordEncoder().encode("wrong-password"))

--- a/src/test/java/com/renzzle/backend/domain/puzzle/community/dao/CommunityPuzzleRepositoryTest.java
+++ b/src/test/java/com/renzzle/backend/domain/puzzle/community/dao/CommunityPuzzleRepositoryTest.java
@@ -1,0 +1,30 @@
+package com.renzzle.backend.domain.puzzle.community.dao;
+
+import com.renzzle.backend.config.DataJpaTestWithInitContainers;
+import com.renzzle.backend.domain.user.dao.UserRepository;
+import com.renzzle.backend.global.init.DataInitializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DataJpaTestWithInitContainers
+public class CommunityPuzzleRepositoryTest {
+
+    @Autowired
+    private DataInitializer dataInitializer;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CommunityPuzzleRepository communityPuzzleRepository;
+
+    @Autowired
+    private UserCommunityPuzzleRepository userCommunityPuzzleRepository;
+
+    @Test
+    public void searchCommunityPuzzles_WhenVariousConditions_ThenReturnsExpectedResults() {
+        // Given
+
+    }
+
+}

--- a/src/test/java/com/renzzle/backend/domain/puzzle/community/dao/UserCommunityPuzzleRepositoryTest.java
+++ b/src/test/java/com/renzzle/backend/domain/puzzle/community/dao/UserCommunityPuzzleRepositoryTest.java
@@ -1,0 +1,17 @@
+package com.renzzle.backend.domain.puzzle.community.dao;
+
+import com.renzzle.backend.config.TestContainersConfig;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@ContextConfiguration(initializers = TestContainersConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class UserCommunityPuzzleRepositoryTest {
+
+
+
+}

--- a/src/test/java/com/renzzle/backend/domain/puzzle/training/service/TrainingServiceRepositoryTest.java
+++ b/src/test/java/com/renzzle/backend/domain/puzzle/training/service/TrainingServiceRepositoryTest.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
-@ActiveProfiles("test")
 @ContextConfiguration(initializers = TestContainersConfig.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class TrainingServiceRepositoryTest {


### PR DESCRIPTION
### ✏️ 작업 개요
@DataJpaTestWithInitContainers 추가

### 🔨 작업 상세 내용
1. @DataJpaTestWithInitContainers 어노테이션 추가
2. 해당 어노테이션으로 Test Container 초기화 및 필수 데이터 초기화
3. DataInitializer 의존성 수정하여 로직 수정 (모두 Repository 빈들을 사용하도록)
