### PR TITLE
LangCode 엔티티 적용

### DIFF
--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/api/request/AddTrainingPuzzleRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/api/request/AddTrainingPuzzleRequest.java
@@ -25,5 +25,5 @@ public record AddTrainingPuzzleRequest(
 
         @NotEmpty(message = "승리 색상 정보가 없습니다")
         @ValidEnum(enumClass = WinColor.WinColorName.class, message = "잘못된 WinColor 타입입니다")
-        WinColor winColor
+        String winColor
 ) { }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/api/request/GetTrainingPackRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/api/request/GetTrainingPackRequest.java
@@ -1,17 +1,19 @@
 package com.renzzle.backend.domain.puzzle.training.api.request;
 
-import com.renzzle.backend.global.common.constant.LanguageCode;
+import com.renzzle.backend.global.common.domain.LangCode;
+import com.renzzle.backend.global.validation.ValidEnum;
 import jakarta.validation.constraints.NotBlank;
 
 public record GetTrainingPackRequest(
         @NotBlank(message = "Difficulty is required")
         String difficulty,
 
-        LanguageCode lang
+        @ValidEnum(enumClass = LangCode.LangCodeName.class, message = "잘못된 lang 형식입니다")
+        String lang
 ) {
     public GetTrainingPackRequest {
-        if (lang == null) {
-            lang = LanguageCode.en;
+        if (lang == null || lang.isBlank()) {
+            lang = "EN";
         }
     }
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/api/request/PackTranslationRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/api/request/PackTranslationRequest.java
@@ -1,11 +1,13 @@
 package com.renzzle.backend.domain.puzzle.training.api.request;
 
 import com.renzzle.backend.global.common.constant.LanguageCode;
+import com.renzzle.backend.global.common.domain.LangCode;
+import com.renzzle.backend.global.validation.ValidEnum;
 import jakarta.validation.constraints.NotBlank;
 
 public record PackTranslationRequest(
-        @NotBlank(message = "langCode는 필수입니다")
-        LanguageCode langCode,
+        @ValidEnum(enumClass = LangCode.LangCodeName.class, message = "잘못된 lang 형식입니다")
+        String langCode,
 
         @NotBlank(message = "title은 필수입니다")
         String title,

--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/api/request/TranslationRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/api/request/TranslationRequest.java
@@ -1,6 +1,8 @@
 package com.renzzle.backend.domain.puzzle.training.api.request;
 
 import com.renzzle.backend.global.common.constant.LanguageCode;
+import com.renzzle.backend.global.common.domain.LangCode;
+import com.renzzle.backend.global.validation.ValidEnum;
 import jakarta.validation.constraints.NotBlank;
 
 public record TranslationRequest(
@@ -8,8 +10,8 @@ public record TranslationRequest(
         @NotBlank(message = "packId는 필수입니다")
         Long packId,
 
-        @NotBlank(message = "langCode는 필수입니다")
-        LanguageCode langCode,
+        @ValidEnum(enumClass = LangCode.LangCodeName.class, message = "잘못된 lang 형식입니다")
+        String langCode,
 
         @NotBlank(message = "title은 필수입니다")
         String title,

--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/dao/PackTranslationRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/dao/PackTranslationRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface PackTranslationRepository extends JpaRepository<PackTranslation, Long> {
-    List<PackTranslation> findAllByPack_IdInAndLanguageCode(List<Long> packIds, String languageCode);
+    List<PackTranslation> findAllByPack_IdInAndLangCode(List<Long> packIds, String languageCode);
 
-    boolean existsByPackAndLanguageCode(Pack pack, String languageCode);
+    boolean existsByPackAndLangCode(Pack pack, String languageCode);
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/dao/PackTranslationRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/dao/PackTranslationRepository.java
@@ -2,12 +2,13 @@ package com.renzzle.backend.domain.puzzle.training.dao;
 
 import com.renzzle.backend.domain.puzzle.training.domain.Pack;
 import com.renzzle.backend.domain.puzzle.training.domain.PackTranslation;
+import com.renzzle.backend.global.common.domain.LangCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface PackTranslationRepository extends JpaRepository<PackTranslation, Long> {
-    List<PackTranslation> findAllByPack_IdInAndLangCode(List<Long> packIds, String languageCode);
+    List<PackTranslation> findAllByPack_IdInAndLangCode(List<Long> packIds, LangCode languageCode);
 
-    boolean existsByPackAndLangCode(Pack pack, String languageCode);
+    boolean existsByPackAndLangCode(Pack pack, LangCode languageCode);
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/domain/PackTranslation.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/domain/PackTranslation.java
@@ -1,7 +1,7 @@
 package com.renzzle.backend.domain.puzzle.training.domain;
 
 
-import com.renzzle.backend.domain.puzzle.training.domain.Pack;
+import com.renzzle.backend.global.common.domain.LangCode;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.OnDelete;
@@ -23,8 +23,10 @@ public class PackTranslation {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Pack pack;
 
-    @Column(name = "language_code", nullable = false, length = 15)
-    private String languageCode;
+    @ManyToOne
+    @JoinColumn(name = "lang_code", nullable = false)
+    @OnDelete(action = OnDeleteAction.NO_ACTION)
+    private LangCode langCode;
 
     @Column(name = "title", nullable = false, length = 225)
     private String title;
@@ -36,4 +38,3 @@ public class PackTranslation {
     private String description;
 
 }
-

--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/service/TrainingService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/service/TrainingService.java
@@ -11,6 +11,7 @@ import com.renzzle.backend.domain.puzzle.training.domain.*;
 import com.renzzle.backend.domain.user.dao.UserRepository;
 import com.renzzle.backend.domain.user.domain.UserEntity;
 import com.renzzle.backend.global.common.constant.ItemPrice;
+import com.renzzle.backend.global.common.domain.LangCode;
 import com.renzzle.backend.global.exception.CustomException;
 import com.renzzle.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -64,7 +65,7 @@ public class TrainingService {
                 .boardKey(boardKey)
                 .depth(request.depth())
                 .rating(rating)
-                .winColor(WinColor.getWinColor(request.winColor().getName()))
+                .winColor(WinColor.getWinColor(request.winColor()))
                 .build();
 
         return trainingPuzzleRepository.save(puzzle);
@@ -145,7 +146,7 @@ public class TrainingService {
         List<PackTranslation> translations = request.info().stream()
                 .map(info -> PackTranslation.builder()
                         .pack(savedPack)
-                        .languageCode(info.langCode().name())
+                        .langCode(LangCode.getLangCode(info.langCode()))
                         .title(info.title())
                         .author(info.author())
                         .description(info.description())
@@ -163,7 +164,7 @@ public class TrainingService {
         Pack pack = packRepository.findById(request.packId())
                 .orElseThrow(() -> new CustomException(ErrorCode.NO_SUCH_TRAINING_PACK));
 
-        boolean exists = packTranslationRepository.existsByPackAndLanguageCode(pack, request.langCode().name());
+        boolean exists = packTranslationRepository.existsByPackAndLangCode(pack, request.langCode());
 
         if (exists) {
             throw new CustomException(ErrorCode.ALREADY_EXISTING_TRANSLATION);
@@ -171,7 +172,7 @@ public class TrainingService {
 
         PackTranslation translation = PackTranslation.builder()
                 .pack(pack)
-                .languageCode(request.langCode().name())
+                .langCode(LangCode.getLangCode(request.langCode()))
                 .title(request.title())
                 .author(request.author())
                 .description(request.description())
@@ -191,7 +192,7 @@ public class TrainingService {
 
         List<Long> packIds = packs.stream().map(Pack::getId).collect(Collectors.toList());
         List<PackTranslation> translations = packTranslationRepository
-                .findAllByPack_IdInAndLanguageCode(packIds, request.lang().name());
+                .findAllByPack_IdInAndLangCode(packIds, request.lang());
 
         Long userId = user.getId();
 
@@ -258,7 +259,6 @@ public class TrainingService {
                 .orElseThrow(() -> new CustomException(ErrorCode.CANNOT_FIND_TRAINING_PUZZLE));
 
         newUser.purchase(ItemPrice.HINT.getPrice());
-//        userRepository.save(newUser);
 
         return GetTrainingPuzzleAnswerResponse.builder()
                 .answer(puzzle.getAnswer())

--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/service/TrainingService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/service/TrainingService.java
@@ -164,7 +164,7 @@ public class TrainingService {
         Pack pack = packRepository.findById(request.packId())
                 .orElseThrow(() -> new CustomException(ErrorCode.NO_SUCH_TRAINING_PACK));
 
-        boolean exists = packTranslationRepository.existsByPackAndLangCode(pack, request.langCode());
+        boolean exists = packTranslationRepository.existsByPackAndLangCode(pack, LangCode.getLangCode(request.langCode()));
 
         if (exists) {
             throw new CustomException(ErrorCode.ALREADY_EXISTING_TRANSLATION);
@@ -192,7 +192,7 @@ public class TrainingService {
 
         List<Long> packIds = packs.stream().map(Pack::getId).collect(Collectors.toList());
         List<PackTranslation> translations = packTranslationRepository
-                .findAllByPack_IdInAndLangCode(packIds, request.lang());
+                .findAllByPack_IdInAndLangCode(packIds, LangCode.getLangCode(request.lang()));
 
         Long userId = user.getId();
 

--- a/src/test/java/com/renzzle/backend/domain/puzzle/training/service/TrainingServiceRepositoryTest.java
+++ b/src/test/java/com/renzzle/backend/domain/puzzle/training/service/TrainingServiceRepositoryTest.java
@@ -299,8 +299,8 @@ public class TrainingServiceRepositoryTest {
         entityManager.persist(difficulty);
 
         List<PackTranslationRequest> translations = Arrays.asList(
-                new PackTranslationRequest(LangCode.getLangCode("EN"), "초보용 1", "재윤", "설명1"),
-                new PackTranslationRequest(LanguageCode.en, "For Beginner 1", "JaeYun", "Description1")
+                new PackTranslationRequest("EN", "초보용 1", "재윤", "설명1"),
+                new PackTranslationRequest("EN", "For Beginner 1", "JaeYun", "Description1")
         );
         CreateTrainingPackRequest request = new CreateTrainingPackRequest(translations, 1000, "LOW");
 
@@ -364,7 +364,7 @@ public class TrainingServiceRepositoryTest {
         // PackTranslation 생성 및 저장 (언어 코드 "EN")
         PackTranslation translation = PackTranslation.builder()
                 .pack(savedPack)
-                .langCode(LangCode.getLangCode(LanguageCode.en.name()))
+                .langCode(LangCode.getLangCode("EN"))
                 .title("Test Title")
                 .author("Test Author")
                 .description("Test Description")
@@ -374,7 +374,7 @@ public class TrainingServiceRepositoryTest {
         // when
         List<Pack> packs = packRepository.findByDifficulty(difficulty);
         List<Long> packIds = packs.stream().map(Pack::getId).collect(Collectors.toList());
-        List<PackTranslation> translations = packTranslationRepository.findAllByPack_IdInAndLangCode(packIds, LanguageCode.en.name());
+        List<PackTranslation> translations = packTranslationRepository.findAllByPack_IdInAndLangCode(packIds, LangCode.getLangCode("EN"));
 
         // then
         assertThat(packs).hasSize(1);
@@ -400,13 +400,13 @@ public class TrainingServiceRepositoryTest {
                 .puzzleCount(0)
                 .build();
         Pack savedPack = packRepository.save(pack);
-        boolean existsBefore = packTranslationRepository.existsByPackAndLangCode(savedPack, LanguageCode.en.name());
+        boolean existsBefore = packTranslationRepository.existsByPackAndLangCode(savedPack, LangCode.getLangCode("EN"));
         assertThat(existsBefore).isFalse();
 
         // when
         PackTranslation translation = PackTranslation.builder()
                 .pack(savedPack)
-                .langCode(LangCode.getLangCode(LanguageCode.en.name()))
+                .langCode(LangCode.getLangCode("EN"))
                 .title("Test Title")
                 .author("Test Author")
                 .description("Test Description")
@@ -418,7 +418,7 @@ public class TrainingServiceRepositoryTest {
         assertThat(translations).hasSize(1);
         PackTranslation retrieved = translations.get(0);
         assertThat(retrieved.getPack().getId()).isEqualTo(savedPack.getId());
-        assertThat(retrieved.getLangCode()).isEqualTo(LanguageCode.en.name());
+        assertThat(retrieved.getLangCode().getName()).isEqualTo("EN");
         assertThat(retrieved.getTitle()).isEqualTo("Test Title");
         assertThat(retrieved.getAuthor()).isEqualTo("Test Author");
         assertThat(retrieved.getDescription()).isEqualTo("Test Description");

--- a/src/test/java/com/renzzle/backend/domain/puzzle/training/service/TrainingServiceRepositoryTest.java
+++ b/src/test/java/com/renzzle/backend/domain/puzzle/training/service/TrainingServiceRepositoryTest.java
@@ -11,6 +11,7 @@ import com.renzzle.backend.domain.user.dao.UserRepository;
 import com.renzzle.backend.domain.user.domain.UserEntity;
 import com.renzzle.backend.global.common.constant.ItemPrice;
 import com.renzzle.backend.global.common.constant.LanguageCode;
+import com.renzzle.backend.global.common.domain.LangCode;
 import com.renzzle.backend.global.common.domain.Status;
 import com.renzzle.backend.support.DataJpaTestWithInitContainers;
 import jakarta.persistence.EntityManager;
@@ -298,7 +299,7 @@ public class TrainingServiceRepositoryTest {
         entityManager.persist(difficulty);
 
         List<PackTranslationRequest> translations = Arrays.asList(
-                new PackTranslationRequest(LanguageCode.ko, "초보용 1", "재윤", "설명1"),
+                new PackTranslationRequest(LangCode.getLangCode("EN"), "초보용 1", "재윤", "설명1"),
                 new PackTranslationRequest(LanguageCode.en, "For Beginner 1", "JaeYun", "Description1")
         );
         CreateTrainingPackRequest request = new CreateTrainingPackRequest(translations, 1000, "LOW");
@@ -315,7 +316,7 @@ public class TrainingServiceRepositoryTest {
         List<PackTranslation> packTranslations = request.info().stream()
                 .map(info -> PackTranslation.builder()
                         .pack(savedPack)
-                        .languageCode(info.langCode().name())
+                        .langCode(LangCode.getLangCode(info.langCode()))
                         .title(info.title())
                         .author(info.author())
                         .description(info.description())
@@ -363,7 +364,7 @@ public class TrainingServiceRepositoryTest {
         // PackTranslation 생성 및 저장 (언어 코드 "EN")
         PackTranslation translation = PackTranslation.builder()
                 .pack(savedPack)
-                .languageCode(LanguageCode.en.name())
+                .langCode(LangCode.getLangCode(LanguageCode.en.name()))
                 .title("Test Title")
                 .author("Test Author")
                 .description("Test Description")
@@ -373,7 +374,7 @@ public class TrainingServiceRepositoryTest {
         // when
         List<Pack> packs = packRepository.findByDifficulty(difficulty);
         List<Long> packIds = packs.stream().map(Pack::getId).collect(Collectors.toList());
-        List<PackTranslation> translations = packTranslationRepository.findAllByPack_IdInAndLanguageCode(packIds, LanguageCode.en.name());
+        List<PackTranslation> translations = packTranslationRepository.findAllByPack_IdInAndLangCode(packIds, LanguageCode.en.name());
 
         // then
         assertThat(packs).hasSize(1);
@@ -399,13 +400,13 @@ public class TrainingServiceRepositoryTest {
                 .puzzleCount(0)
                 .build();
         Pack savedPack = packRepository.save(pack);
-        boolean existsBefore = packTranslationRepository.existsByPackAndLanguageCode(savedPack, LanguageCode.en.name());
+        boolean existsBefore = packTranslationRepository.existsByPackAndLangCode(savedPack, LanguageCode.en.name());
         assertThat(existsBefore).isFalse();
 
         // when
         PackTranslation translation = PackTranslation.builder()
                 .pack(savedPack)
-                .languageCode(LanguageCode.en.name())
+                .langCode(LangCode.getLangCode(LanguageCode.en.name()))
                 .title("Test Title")
                 .author("Test Author")
                 .description("Test Description")
@@ -417,7 +418,7 @@ public class TrainingServiceRepositoryTest {
         assertThat(translations).hasSize(1);
         PackTranslation retrieved = translations.get(0);
         assertThat(retrieved.getPack().getId()).isEqualTo(savedPack.getId());
-        assertThat(retrieved.getLanguageCode()).isEqualTo(LanguageCode.en.name());
+        assertThat(retrieved.getLangCode()).isEqualTo(LanguageCode.en.name());
         assertThat(retrieved.getTitle()).isEqualTo("Test Title");
         assertThat(retrieved.getAuthor()).isEqualTo("Test Author");
         assertThat(retrieved.getDescription()).isEqualTo("Test Description");

--- a/src/test/java/com/renzzle/backend/domain/puzzle/training/service/TrainingServiceTest.java
+++ b/src/test/java/com/renzzle/backend/domain/puzzle/training/service/TrainingServiceTest.java
@@ -137,7 +137,10 @@ public class TrainingServiceTest {
             );
 
             when(packRepository.findById(packId)).thenReturn(Optional.of(pack));
-            when(packTranslationRepository.existsByPackAndLangCode(pack, request.langCode())).thenReturn(false);
+            when(packTranslationRepository.existsByPackAndLangCode(
+                    eq(pack),
+                    argThat(langCode -> langCode != null && langCode.getName().equals("EN"))
+            )).thenReturn(false);
 
             // when
             trainingService.addTranslation(request);
@@ -150,7 +153,7 @@ public class TrainingServiceTest {
 
             PackTranslation savedTranslation = captor.getValue();
             assertEquals(pack, savedTranslation.getPack());
-            assertEquals(LangCode.getLangCode(request.langCode()), savedTranslation.getLangCode());
+            assertEquals(request.langCode(), savedTranslation.getLangCode().getName());
             assertEquals(request.title(), savedTranslation.getTitle());
             assertEquals(request.author(), savedTranslation.getAuthor());
             assertEquals(request.description(), savedTranslation.getDescription());
@@ -163,7 +166,7 @@ public class TrainingServiceTest {
             Long packId = 1L;
             String boardStatus = "a1a2a3a4";
             Integer depth = 3;
-            String winColorStr = "white";
+            String winColorStr = "WHITE";
             AddTrainingPuzzleRequest request = new AddTrainingPuzzleRequest(
                     packId,
                     null,
@@ -391,13 +394,18 @@ public class TrainingServiceTest {
             // PackTranslation 생성 (연결된 pack의 ID 1)
             PackTranslation translation = PackTranslation.builder()
                     .pack(pack)
-                    .langCode(LangCode.getLangCode(LanguageCode.en.name()))
+                    .langCode(LangCode.getLangCode("EN"))
                     .title("Title")
                     .author("Author")
                     .description("Description")
                     .build();
-            when(packTranslationRepository.findAllByPack_IdInAndLangCode(List.of(1L), LanguageCode.en.name()))
-                    .thenReturn(Collections.singletonList(translation));
+
+            LangCode langCode = LangCode.getLangCode("EN");
+
+            when(packTranslationRepository.findAllByPack_IdInAndLangCode(
+                    eq(List.of(1L)),
+                    argThat(arg -> arg.getName().equals("EN"))
+            )).thenReturn(List.of(translation));
 
             // userPackRepository: 사용자가 해당 pack에 대한 기록이 없으므로, 빈 리스트 반환 (locked = true, solvedCount = 0)
             when(userPackRepository.findAllByUserIdAndPackIdIn(100L, List.of(1L)))
@@ -506,6 +514,7 @@ public class TrainingServiceTest {
             // given
             Long packId = 1L;
             Pack pack = Pack.builder().id(packId).build();
+            LangCode langCode = LangCode.getLangCode("EN");
             TranslationRequest request = new TranslationRequest(
                     packId,
                     "EN",
@@ -515,7 +524,8 @@ public class TrainingServiceTest {
             );
 
             when(packRepository.findById(packId)).thenReturn(Optional.of(pack));
-            when(packTranslationRepository.existsByPackAndLangCode(pack, request.langCode())).thenReturn(true);
+            when(packTranslationRepository.existsByPackAndLangCode(eq(pack), argThat(arg -> arg.getName().equals("EN"))))
+                    .thenReturn(true);
 
             // when
             CustomException exception = assertThrows(CustomException.class, () -> trainingService.addTranslation(request));
@@ -554,7 +564,7 @@ public class TrainingServiceTest {
             Long packId = 1L;
             String boardStatus = "a1a2a3a4";
             Integer depth = 3;
-            String winColorStr = "white";
+            String winColorStr = "WHITE";
 
             AddTrainingPuzzleRequest request = new AddTrainingPuzzleRequest(
                     packId,

--- a/src/test/java/com/renzzle/backend/domain/puzzle/training/service/TrainingServiceTest.java
+++ b/src/test/java/com/renzzle/backend/domain/puzzle/training/service/TrainingServiceTest.java
@@ -16,6 +16,7 @@ import com.renzzle.backend.domain.user.dao.UserRepository;
 import com.renzzle.backend.domain.user.domain.UserEntity;
 import com.renzzle.backend.global.common.constant.ItemPrice;
 import com.renzzle.backend.global.common.constant.LanguageCode;
+import com.renzzle.backend.global.common.domain.LangCode;
 import com.renzzle.backend.global.common.domain.Status;
 import com.renzzle.backend.global.exception.CustomException;
 import com.renzzle.backend.global.exception.ErrorCode;
@@ -79,8 +80,8 @@ public class TrainingServiceTest {
         public void testCreatePack() {
             // given
             List<PackTranslationRequest> translationRequests = Arrays.asList(
-                    new PackTranslationRequest(LanguageCode.ko, "초보용 1", "강상민", "처음 퍼즐을 푸는..."),
-                    new PackTranslationRequest(LanguageCode.en, "For Beginner 1", "Kang Sang-Min", "First time to solve...")
+                    new PackTranslationRequest("KO", "초보용 1", "강상민", "처음 퍼즐을 푸는..."),
+                    new PackTranslationRequest("EN", "For Beginner 1", "Kang Sang-Min", "First time to solve...")
             );
             CreateTrainingPackRequest request = new CreateTrainingPackRequest(translationRequests, 1000, "LOW");
 
@@ -96,7 +97,7 @@ public class TrainingServiceTest {
             List<PackTranslation> expectedTranslations = request.info().stream()
                     .map(info -> PackTranslation.builder()
                             .pack(savedPack)
-                            .languageCode(info.langCode().name())
+                            .langCode(LangCode.getLangCode(info.langCode()))
                             .title(info.title())
                             .author(info.author())
                             .description(info.description())
@@ -129,14 +130,14 @@ public class TrainingServiceTest {
 
             TranslationRequest request = new TranslationRequest(
                     packId,
-                    LanguageCode.en,
+                    "EN",
                     "For Beginner 1",
                     "Kang Sang-Min",
                     "First time to solve..."
             );
 
             when(packRepository.findById(packId)).thenReturn(Optional.of(pack));
-            when(packTranslationRepository.existsByPackAndLanguageCode(pack, request.langCode().name())).thenReturn(false);
+            when(packTranslationRepository.existsByPackAndLangCode(pack, request.langCode())).thenReturn(false);
 
             // when
             trainingService.addTranslation(request);
@@ -149,7 +150,7 @@ public class TrainingServiceTest {
 
             PackTranslation savedTranslation = captor.getValue();
             assertEquals(pack, savedTranslation.getPack());
-            assertEquals(request.langCode().name(), savedTranslation.getLanguageCode());
+            assertEquals(LangCode.getLangCode(request.langCode()), savedTranslation.getLangCode());
             assertEquals(request.title(), savedTranslation.getTitle());
             assertEquals(request.author(), savedTranslation.getAuthor());
             assertEquals(request.description(), savedTranslation.getDescription());
@@ -162,8 +163,7 @@ public class TrainingServiceTest {
             Long packId = 1L;
             String boardStatus = "a1a2a3a4";
             Integer depth = 3;
-            WinColor winColorStr = WinColor.getWinColor("WHITE"); // WinColor의 유효한 값이라고 가정
-
+            String winColorStr = "white";
             AddTrainingPuzzleRequest request = new AddTrainingPuzzleRequest(
                     packId,
                     null,
@@ -197,7 +197,7 @@ public class TrainingServiceTest {
                     .boardKey("generatedKey")
                     .depth(depth)
                     .rating(depth * 200) // TODO: RatingUtils로 레이팅 계산식 관리
-                    .winColor(winColorStr)
+                    .winColor(WinColor.getWinColor(winColorStr))
                     .build();
 
             when(trainingPuzzleRepository.save(any(TrainingPuzzle.class))).thenReturn(savedPuzzle);
@@ -391,12 +391,12 @@ public class TrainingServiceTest {
             // PackTranslation 생성 (연결된 pack의 ID 1)
             PackTranslation translation = PackTranslation.builder()
                     .pack(pack)
-                    .languageCode(LanguageCode.en.name())
+                    .langCode(LangCode.getLangCode(LanguageCode.en.name()))
                     .title("Title")
                     .author("Author")
                     .description("Description")
                     .build();
-            when(packTranslationRepository.findAllByPack_IdInAndLanguageCode(List.of(1L), LanguageCode.en.name()))
+            when(packTranslationRepository.findAllByPack_IdInAndLangCode(List.of(1L), LanguageCode.en.name()))
                     .thenReturn(Collections.singletonList(translation));
 
             // userPackRepository: 사용자가 해당 pack에 대한 기록이 없으므로, 빈 리스트 반환 (locked = true, solvedCount = 0)
@@ -508,14 +508,14 @@ public class TrainingServiceTest {
             Pack pack = Pack.builder().id(packId).build();
             TranslationRequest request = new TranslationRequest(
                     packId,
-                    LanguageCode.en,
+                    "EN",
                     "For Beginner 1",
                     "Kang Sang-Min",
                     "First time to solve..."
             );
 
             when(packRepository.findById(packId)).thenReturn(Optional.of(pack));
-            when(packTranslationRepository.existsByPackAndLanguageCode(pack, request.langCode().name())).thenReturn(true);
+            when(packTranslationRepository.existsByPackAndLangCode(pack, request.langCode())).thenReturn(true);
 
             // when
             CustomException exception = assertThrows(CustomException.class, () -> trainingService.addTranslation(request));
@@ -532,7 +532,7 @@ public class TrainingServiceTest {
             Long packId = 1L;
             TranslationRequest request = new TranslationRequest(
                     packId,
-                    LanguageCode.en,
+                    "EN",
                     "For Beginner 1",
                     "tintin",
                     "First time to solve..."
@@ -554,7 +554,7 @@ public class TrainingServiceTest {
             Long packId = 1L;
             String boardStatus = "a1a2a3a4";
             Integer depth = 3;
-            WinColor winColorStr = WinColor.getWinColor("WHITE");
+            String winColorStr = "white";
 
             AddTrainingPuzzleRequest request = new AddTrainingPuzzleRequest(
                     packId,


### PR DESCRIPTION
### ✏️ 작업 개요
기존 ENUM으로 처리하던 언어 코드를 엔티티로 리펙토링되었기 때문에 이를 적용
### 🔨 작업 상세 내용
1. langcode를 사용하던 기존 request & response를 모두 수정
2. test code 에서 사용하던 langcode 수정
### ✅ 이슈 연관
#57 

