### PR TITLE
hotfix: post readonly issue & request validation mismatch & solve misuse of pack_id in packRepository

### DIFF
--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/api/request/AddTrainingPuzzleRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/api/request/AddTrainingPuzzleRequest.java
@@ -11,6 +11,7 @@ public record AddTrainingPuzzleRequest(
         @NotNull(message = "팩 정보가 없습니다")
         Long packId,
 
+        @NotNull
         Integer puzzleIndex,
 
         @NotEmpty(message = "보드 정보가 없습니다")

--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/api/request/TranslationRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/api/request/TranslationRequest.java
@@ -4,10 +4,11 @@ import com.renzzle.backend.global.common.constant.LanguageCode;
 import com.renzzle.backend.global.common.domain.LangCode;
 import com.renzzle.backend.global.validation.ValidEnum;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record TranslationRequest(
 
-        @NotBlank(message = "packId는 필수입니다")
+        @NotNull(message = "packId는 필수입니다")
         Long packId,
 
         @ValidEnum(enumClass = LangCode.LangCodeName.class, message = "잘못된 lang 형식입니다")

--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/dao/PackRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/dao/PackRepository.java
@@ -17,7 +17,7 @@ public interface PackRepository extends JpaRepository<Pack, Long> {
     @Transactional
     @Query(value = "UPDATE pack " +
             "SET puzzle_count = puzzle_count + 1 " +
-            "WHERE pack_id = :packId",
+            "WHERE id = :packId",
             nativeQuery = true)
     void increasePuzzleCount(@Param("packId") Long packId);
 

--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/service/TrainingService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/service/TrainingService.java
@@ -95,7 +95,7 @@ public class TrainingService {
             existInfo.get().updateSolvedAtToNow(clock);
             return SolveTrainingPuzzleResponse.builder()
                     .reward(0)
-                    .build(); // ✅ 이미 풀었다면 리워드 없음
+                    .build();
         }
 
         TrainingPuzzle trainingPuzzle = trainingPuzzleRepository.findById(puzzleId)
@@ -252,7 +252,7 @@ public class TrainingService {
     }
 
     // service test, repo test
-    @Transactional(readOnly = true)
+    @Transactional
     public GetPackPurchaseResponse purchaseTrainingPack(UserEntity user, PurchaseTrainingPackRequest request) {
         Pack pack = packRepository.findById(request.packId())
                 .orElseThrow(() -> new CustomException(ErrorCode.NO_SUCH_TRAINING_PACK));
@@ -273,7 +273,7 @@ public class TrainingService {
                 .build();
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public GetTrainingPuzzleAnswerResponse purchaseTrainingPuzzleAnswer(UserEntity user, PurchaseTrainingPuzzleAnswerRequest request) {
         UserEntity newUser = userRepository.findById(user.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.CANNOT_FIND_USER));

--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/service/TrainingService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/service/TrainingService.java
@@ -45,16 +45,17 @@ public class TrainingService {
     // service test, repo test
     @Transactional
     public TrainingPuzzle createTrainingPuzzle(AddTrainingPuzzleRequest request) {
-        String boardKey = BoardUtils.makeBoardKey(request.boardStatus());
-
-        int index = trainingPuzzleRepository.findTopIndex(request.packId()) + 1;
-        if(request.puzzleIndex() != null && index > request.puzzleIndex()) {
-            index = request.puzzleIndex();
-            trainingPuzzleRepository.increaseIndexesFrom(request.packId(), index);
-        }
 
         Pack pack = packRepository.findById(request.packId())
                 .orElseThrow(() -> new CustomException(ErrorCode.NO_SUCH_TRAINING_PACK));
+
+        String boardKey = BoardUtils.makeBoardKey(request.boardStatus());
+
+        int index = trainingPuzzleRepository.findTopIndex(request.packId()) + 1;
+        if(index > request.puzzleIndex()) {
+            index = request.puzzleIndex();
+            trainingPuzzleRepository.increaseIndexesFrom(request.packId(), index);
+        }
 
         double rating = request.depth() * DEFAULT_PUZZLE_RATING;
 

--- a/src/test/java/com/renzzle/backend/domain/puzzle/training/service/TrainingServiceTest.java
+++ b/src/test/java/com/renzzle/backend/domain/puzzle/training/service/TrainingServiceTest.java
@@ -164,7 +164,7 @@ public class TrainingServiceTest {
             String winColorStr = "WHITE";
             AddTrainingPuzzleRequest request = new AddTrainingPuzzleRequest(
                     packId,
-                    null,
+                    6,
                     boardStatus,
                     "a1a2a3a4",
                     depth,


### PR DESCRIPTION
### ✏️ 작업 개요
purchaseTrainingPack 과 purchaseTrainingPuzzleAnswer POST API 서비스 코드에 readOnly를 작성하여 POST 메소드가 동작하지 않음
TranslationRequest 의 PackId의 Validation으로 NotNull을 사용하여야 했는데, NotBlank로 사용하여 자료형이 다른 문제 발생
PackRepository의 increasePuzzleCount에서 잘못 사용되던 pack_id 를 id 로 알맞게 수정