### PR TITLE
트레이닝 문제 삭제 시 pack Count 감소 & 트레이닝 문제 조회 시 오름차순 조회

### DIFF
--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/dao/PackRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/dao/PackRepository.java
@@ -21,6 +21,14 @@ public interface PackRepository extends JpaRepository<Pack, Long> {
             nativeQuery = true)
     void increasePuzzleCount(@Param("packId") Long packId);
 
+    @Modifying
+    @Transactional
+    @Query(value = "UPDATE pack " +
+            "SET puzzle_count = puzzle_count - 1 " +
+            "WHERE id = :packId",
+            nativeQuery = true)
+    void decreasePuzzleCount(@Param("packId") Long packId);
+
     List<Pack> findByDifficulty(Difficulty difficulty);
 
     Optional<Pack> findFirstByOrderByIdAsc();

--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/dao/TrainingPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/dao/TrainingPuzzleRepository.java
@@ -47,8 +47,8 @@ public interface TrainingPuzzleRepository extends JpaRepository<TrainingPuzzle, 
             nativeQuery = true)
     int countAllTrainingByChapter(@Param("chapter") int chapter);
 
+    List<TrainingPuzzle> findByPack_IdOrderByTrainingIndex(Long packId);
 
-    List<TrainingPuzzle> findByPack_IdOrderByTrainingIndexDesc(Long packId);
 
 
     @Query("SELECT p FROM TrainingPuzzle p " +

--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/service/TrainingService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/service/TrainingService.java
@@ -85,6 +85,8 @@ public class TrainingService {
 
         trainingPuzzleRepository.deleteById(puzzleId);
         trainingPuzzleRepository.decreaseIndexesFrom(puzzle.get().getTrainingIndex());
+
+        packRepository.decreasePuzzleCount(puzzle.get().getPack().getId());
     }
 
     // service test, repo test
@@ -132,7 +134,7 @@ public class TrainingService {
         }
 
         //TODO : training index 순서대로 반환할 수 있도록
-        List<TrainingPuzzle> trainingPuzzles = trainingPuzzleRepository.findByPack_IdOrderByTrainingIndexDesc(packId);
+        List<TrainingPuzzle> trainingPuzzles = trainingPuzzleRepository.findByPack_IdOrderByTrainingIndex(packId);
 
         if(trainingPuzzles.isEmpty()) {
             throw new CustomException(ErrorCode.NO_SUCH_TRAINING_PACK);

--- a/src/test/java/com/renzzle/backend/domain/puzzle/training/service/TrainingServiceRepositoryTest.java
+++ b/src/test/java/com/renzzle/backend/domain/puzzle/training/service/TrainingServiceRepositoryTest.java
@@ -254,7 +254,7 @@ public class TrainingServiceRepositoryTest {
         trainingPuzzleRepository.save(puzzle2);
 
         // When
-        List<TrainingPuzzle> puzzles = trainingPuzzleRepository.findByPack_IdOrderByTrainingIndexDesc(savedPack.getId());
+        List<TrainingPuzzle> puzzles = trainingPuzzleRepository.findByPack_IdOrderByTrainingIndex(savedPack.getId());
 
         // Then
         assertThat(puzzles).isNotEmpty();

--- a/src/test/java/com/renzzle/backend/domain/puzzle/training/service/TrainingServiceTest.java
+++ b/src/test/java/com/renzzle/backend/domain/puzzle/training/service/TrainingServiceTest.java
@@ -226,9 +226,19 @@ public class TrainingServiceTest {
             // given
             Long puzzleId = 1L;
             int trainingIndex = 5;
+            Long packId = 10L;
+
+            Pack pack = Pack.builder()
+                    .id(packId)
+                    .puzzleCount(3)
+                    .price(1000)
+                    .difficulty(Difficulty.getDifficulty("LOW"))
+                    .build();
+
             TrainingPuzzle puzzle = TrainingPuzzle.builder()
                     .id(puzzleId)
                     .trainingIndex(trainingIndex)
+                    .pack(pack)
                     .build();
 
             when(trainingPuzzleRepository.findById(puzzleId)).thenReturn(Optional.of(puzzle));
@@ -240,6 +250,7 @@ public class TrainingServiceTest {
             verify(trainingPuzzleRepository, times(1)).findById(puzzleId);
             verify(trainingPuzzleRepository, times(1)).deleteById(puzzleId);
             verify(trainingPuzzleRepository, times(1)).decreaseIndexesFrom(trainingIndex);
+            verify(packRepository, times(1)).decreasePuzzleCount(packId);
         }
 
         @DisplayName("SolveLessonPuzzle: 주어진 user와 puzzleId에 대해 최초 풀이라면 solvedTrainingPuzzle이 저장")
@@ -345,7 +356,7 @@ public class TrainingServiceTest {
                     .winColor(winColor)
                     .build();
             List<TrainingPuzzle> puzzles = Collections.singletonList(puzzle);
-            when(trainingPuzzleRepository.findByPack_IdOrderByTrainingIndexDesc(packId)).thenReturn(puzzles);
+            when(trainingPuzzleRepository.findByPack_IdOrderByTrainingIndex(packId)).thenReturn(puzzles);
 
             // solvedTrainingPuzzleRepository.existsByUserAndPuzzle(user, puzzle) 가 false라고 가정
             when(solvedTrainingPuzzleRepository.existsByUserAndPuzzle(user, puzzle)).thenReturn(false);
@@ -668,7 +679,7 @@ public class TrainingServiceTest {
                     .status(Status.getDefaultStatus())
                     .build();
 
-            when(trainingPuzzleRepository.findByPack_IdOrderByTrainingIndexDesc(packId)).thenReturn(Collections.emptyList());
+            when(trainingPuzzleRepository.findByPack_IdOrderByTrainingIndex(packId)).thenReturn(Collections.emptyList());
 
             // when & then
             CustomException exception = assertThrows(CustomException.class, () ->


### PR DESCRIPTION
### ✏️ 작업 개요
1. deleteTrainingPuzzle 시 Pack의 puzzle_count 감소되지 않는 문제 해결
2. getTrainingPuzzleList 시 training index를 기준으로 오름차순으로 조회 가능하도록 수정

