### PR TITLE
랭킹전 문제 출제 오류 수정

### DIFF
--- a/src/main/java/com/renzzle/backend/domain/puzzle/rank/service/RankService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/rank/service/RankService.java
@@ -141,7 +141,7 @@ public class RankService {
         배수 적용 하여 mmr % rating 값 조정 및 변수 값 업데이트
          */
         if (request.isSolved()) {
-            WinProbability += WIN_PROBABILITY_DELTA;
+            WinProbability -= WIN_PROBABILITY_DELTA;
 
             double mmrIncrease = ELOUtils.calculateMMRIncrease(userBeforeMmr, lastProblemRating);
             double ratingIncrease = ELOUtils.calculateRatingIncrease(userBeforeRating, lastProblemRating);
@@ -152,7 +152,7 @@ public class RankService {
             userBeforeMmr = userBeforeMmr + mmrIncrease;
             userBeforeRating = userBeforeRating + ratingIncrease;
         } else {
-            WinProbability -= WIN_PROBABILITY_DELTA;
+            WinProbability += WIN_PROBABILITY_DELTA;
             double mmrDecrease = ELOUtils.calculateMMRDecrease(userBeforeMmr, lastProblemRating);
             double ratingDecrease = ELOUtils.calculateRatingDecrease(userBeforeRating, lastProblemRating);
 
@@ -229,10 +229,6 @@ public class RankService {
     }
 
     NextPuzzleResult getNextPuzzle(double originalMmr, double targetWinProbability, UserEntity user) {
-
-        log.info("originalMmr: {}", originalMmr);
-        log.info("targetWinProbability: {}", targetWinProbability);
-
         /*
             사용자의 레이팅 & 기대 승률 을 통해 적합한 문제를 가져옴
             문제들을
@@ -244,7 +240,6 @@ public class RankService {
         // 각 퍼즐 후보군 가져오기 (레이팅 기준 정렬)
         List<TrainingPuzzle> trainingPuzzles =
                 trainingPuzzleRepository.findAvailableTrainingPuzzlesSortedByRating(user);
-        log.info("Available training puzzles count: {}", trainingPuzzles.size());
         List<CommunityPuzzle> communityPuzzles =
                 communityPuzzleRepository.findAvailableCommunityPuzzlesSortedByRating(user);
 


### PR DESCRIPTION
### ✏️ 작업 개요
랭킹전 문제 출제 시 다음 문제 승률 증감이 반대로 되어 있었기 때문에 적절한 레이팅을 기준으로 삼지 못함.
### 🔨 작업 상세 내용
1. 사용자가 이전 문제를 맞췄다면 다음 문제는 더 어려운 즉, 승률이 낮은 문제를 제공했어야 하나 승률이 높은 문제를 제공함으로써 문제를 맞출수록 사용자의 레이팅은 올라가나 다음 문제의 기준 레이팅은 내려가는 현상으로 인해 오류가 발생했었음.