### PR TITLE
디폴트 LangCode 지정 & GetRecommendRequest 리펙토링 & findTopByUserOrderBySolvedAtDesc 리펙토링

### DIFF
--- a/src/main/java/com/renzzle/backend/domain/puzzle/content/api/ContentController.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/content/api/ContentController.java
@@ -11,10 +11,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/content")
@@ -25,7 +22,7 @@ public class ContentController {
     @Operation(summary = "Get recommend Pack", description = "Get recommend Pack")
     @GetMapping("/recommend")
     public ApiResponse<getRecommendPackResponse> getRecommendPack(
-            @Valid @RequestBody GetRecommendRequest request,
+            @Valid @ModelAttribute GetRecommendRequest request,
             @AuthenticationPrincipal UserDetailsImpl user
     ) {
         getRecommendPackResponse response = contentService.getRecommendedPack(request, user.getUser());

--- a/src/main/java/com/renzzle/backend/domain/puzzle/content/api/request/GetRecommendRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/content/api/request/GetRecommendRequest.java
@@ -1,18 +1,9 @@
 package com.renzzle.backend.domain.puzzle.content.api.request;
 
-import com.renzzle.backend.global.common.constant.LanguageCode;
 import com.renzzle.backend.global.common.domain.LangCode;
 import com.renzzle.backend.global.validation.ValidEnum;
-import jakarta.validation.constraints.NotBlank;
 
 public record GetRecommendRequest(
-        @NotBlank(message = "Difficulty is required")
-        String difficulty,
-
         @ValidEnum(enumClass = LangCode.LangCodeName.class, message = "잘못된 lang 형식입니다")
         String langCode
-) {
-//    public LangCode toLangCode() {
-//        return LangCode.getLangCode(langCode);
-//    }
-}
+) { }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/api/request/GetTrainingPackRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/api/request/GetTrainingPackRequest.java
@@ -4,10 +4,10 @@ import com.renzzle.backend.global.common.domain.LangCode;
 import com.renzzle.backend.global.validation.ValidEnum;
 import jakarta.validation.constraints.NotBlank;
 
-public record GetTrainingPackRequest(
-        @NotBlank(message = "Difficulty is required")
-        String difficulty,
+        public record GetTrainingPackRequest(
+                @NotBlank(message = "Difficulty is required")
+                String difficulty,
 
-        @ValidEnum(enumClass = LangCode.LangCodeName.class, message = "잘못된 lang 형식입니다")
-        String lang
-) { }
+                @ValidEnum(enumClass = LangCode.LangCodeName.class, message = "잘못된 lang 형식입니다")
+                String lang
+        ) { }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/training/dao/SolvedTrainingPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/training/dao/SolvedTrainingPuzzleRepository.java
@@ -32,7 +32,7 @@ public interface SolvedTrainingPuzzleRepository extends JpaRepository<SolvedTrai
             "JOIN FETCH s.puzzle p " +
             "JOIN FETCH p.pack pack " +
             "WHERE s.user.id = :userId " +
-            "ORDER BY s.solvedAt DESC")
+            "ORDER BY s.solvedAt DESC LIMIT 1")
     Optional<SolvedTrainingPuzzle> findTopByUserOrderBySolvedAtDesc(@Param("userId") Long userId);
 
     List<SolvedTrainingPuzzle> findAllByPuzzleId(Long puzzleId);

--- a/src/test/java/com/renzzle/backend/domain/puzzle/content/service/ContentServiceTest.java
+++ b/src/test/java/com/renzzle/backend/domain/puzzle/content/service/ContentServiceTest.java
@@ -124,7 +124,7 @@ public class ContentServiceTest {
                 .thenReturn(Optional.of(userPack));
 
         // When
-        getRecommendPackResponse response = contentService.getRecommendedPack(new GetRecommendRequest("MIDDLE", "EN"), user);
+        getRecommendPackResponse response = contentService.getRecommendedPack(new GetRecommendRequest("EN"), user);
 
         // Then
         assertThat(response.id()).isEqualTo(pack.getId());
@@ -157,7 +157,7 @@ public class ContentServiceTest {
                 .thenReturn(Optional.of(translation));
 
         // When
-        getRecommendPackResponse response = contentService.getRecommendedPack(new GetRecommendRequest("MIDDLE", "EN"), user);
+        getRecommendPackResponse response = contentService.getRecommendedPack(new GetRecommendRequest("EN"), user);
 
         // Then
         assertThat(response.id()).isEqualTo(pack.getId());
@@ -176,7 +176,7 @@ public class ContentServiceTest {
                 .thenReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> contentService.getRecommendedPack(new GetRecommendRequest("LOW", "EN"), user))
+        assertThatThrownBy(() -> contentService.getRecommendedPack(new GetRecommendRequest("EN"), user))
                 .isInstanceOf(CustomException.class)
                 .hasMessageContaining(ErrorCode.NO_SUCH_TRAINING_PACK.getMessage());
     }
@@ -198,7 +198,7 @@ public class ContentServiceTest {
                 .thenReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> contentService.getRecommendedPack(new GetRecommendRequest("MIDDLE", "EN"), user))
+        assertThatThrownBy(() -> contentService.getRecommendedPack(new GetRecommendRequest("EN"), user))
                 .isInstanceOf(CustomException.class)
                 .hasMessageContaining(ErrorCode.NO_SUCH_PACK_TRANSLATION.getMessage());
     }
@@ -242,7 +242,7 @@ public class ContentServiceTest {
                 .thenReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> contentService.getRecommendedPack(new GetRecommendRequest("LOW", "EN"), user))
+        assertThatThrownBy(() -> contentService.getRecommendedPack(new GetRecommendRequest("EN"), user))
                 .isInstanceOf(CustomException.class)
                 .hasMessageContaining(ErrorCode.NO_USER_PROGRESS_FOR_PACK.getMessage());
     }


### PR DESCRIPTION
### ✏️ 작업 개요
디폴트 LangCode EN으로 지정
GetRecommendRequest 는 GET 메소드에서 사용하기 때문에 RequestBody 가 아니라 ModelAttribute 를 사용하여야 하고, 사용하고 있지 않던 Difficulty 필드 삭제
findTopByUserOrderBySolvedAtDesc 시 단일 객체를 가져왔어야 하는데 이를 보장해주기 위한 리펙토링
### 🔨 작업 상세 내용
1. Pack을 조회 시 사용자가 원하는 언어코드의 언어가 아직 존재하지 않을 때 영어로 된 번역본을 제공할 수 있도록 함
2. GetRecommendRequest을 리펙토링
3. findTopByUserOrderBySolvedAtDesc 로 추천 팩을 위한 사용자의 최근 트레이닝 문제를 조회할 때 하나의 문제만 가져올 수 있도록 보장
