### PR TITLE
Fix/get ranking

### DIFF
--- a/src/main/java/com/renzzle/backend/domain/puzzle/rank/service/RankService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/rank/service/RankService.java
@@ -9,13 +9,13 @@ import com.renzzle.backend.domain.puzzle.rank.dao.LatestRankPuzzleRepository;
 import com.renzzle.backend.domain.puzzle.rank.domain.LatestRankPuzzle;
 import com.renzzle.backend.domain.puzzle.rank.domain.RankSessionData;
 import com.renzzle.backend.domain.puzzle.rank.service.dto.NextPuzzleResult;
+import com.renzzle.backend.domain.puzzle.shared.util.ELOUtils;
 import com.renzzle.backend.domain.puzzle.training.dao.TrainingPuzzleRepository;
 import com.renzzle.backend.domain.puzzle.training.domain.TrainingPuzzle;
 import com.renzzle.backend.domain.user.dao.UserRepository;
 import com.renzzle.backend.domain.user.domain.UserEntity;
 import com.renzzle.backend.global.exception.CustomException;
 import com.renzzle.backend.global.exception.ErrorCode;
-import com.renzzle.backend.domain.puzzle.shared.util.ELOUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -542,7 +542,8 @@ public class RankService {
             int dislikes = communityPuzzleRepository.sumDislikesByUser(user.getId());
             int c = Math.max(0, likes - dislikes);
 
-            double score = Math.log(a * Math.pow(b, 2) * Math.pow(c, 3) + 1) * 100;
+            double score = Math.log((a + 1) * Math.pow(b + 1, 2) * Math.pow(c + 1, 3) + 1) * 100;
+            score = Math.floor(score);
 
             UserPuzzlerRankInfo info = UserPuzzlerRankInfo.builder()
                     .rank(0)

--- a/src/main/java/com/renzzle/backend/domain/puzzle/rank/service/RankService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/rank/service/RankService.java
@@ -374,7 +374,6 @@ public class RankService {
         List<UserRatingRankInfo> top100 = extractTopRankedUsers(
                 key,
                 UserRatingRankInfo::rating,
-                UserRatingRankInfo::nickname,
                 (rank, info) -> UserRatingRankInfo.builder()
                         .rank(rank)
                         .nickname(info.nickname())
@@ -407,7 +406,6 @@ public class RankService {
         List<UserPuzzlerRankInfo> top100 = extractTopRankedUsers(
                 key,
                 UserPuzzlerRankInfo::score,
-                UserPuzzlerRankInfo::nickname,
                 (rank, info) -> UserPuzzlerRankInfo.builder()
                         .rank(rank)
                         .nickname(info.nickname())
@@ -445,7 +443,6 @@ public class RankService {
     private <T, R> List<R> extractTopRankedUsers(
             String key,
             Function<T, Double> scoreExtractor,
-            Function<T, String> nicknameExtractor,
             BiFunction<Integer, T, R> builder
     ) {
         Set<ZSetOperations.TypedTuple<Object>> rawSet =


### PR DESCRIPTION
### ✏️ 작업 개요
puzzler rank score 계산 시 log 를 사용하였기 때문에 디폴트 값이 0 이 아닌 1이어야 제대로 계산이 됨.
### 🔨 작업 상세 내용
1. score 계산식의 각 변수의 디폴트 값에 +1씩 해줌으로써 기본 값을 1로 지정하여 계산이 정상적으로 출력되게 함.
2. 더불어 double 타입이기 때문에 소수점까지 출력될 수 있기 때문에 이를 고려하여 수정완료
