### PR TITLE
보고된 버그 수정

### DIFF
--- a/src/main/java/com/renzzle/backend/domain/puzzle/community/dao/CommunityPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/community/dao/CommunityPuzzleRepository.java
@@ -37,7 +37,7 @@ public interface CommunityPuzzleRepository extends JpaRepository<CommunityPuzzle
             "LIMIT :size", nativeQuery = true)
     List<CommunityPuzzle> getUserPuzzles(@Param("userId") Long userId, @Param("cursorId") Long cursorId, @Param("size") int size);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("UPDATE CommunityPuzzle cp SET cp.status = (SELECT s FROM Status s WHERE s.name = 'DELETED'), " +
             "cp.deletedAt = :deletedAt WHERE cp.id = :puzzleId")
     int softDelete(@Param("puzzleId") Long puzzleId, @Param("deletedAt") Instant deletedAt);

--- a/src/main/java/com/renzzle/backend/domain/puzzle/community/dao/CommunityPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/community/dao/CommunityPuzzleRepository.java
@@ -16,7 +16,7 @@ public interface CommunityPuzzleRepository extends JpaRepository<CommunityPuzzle
 
     @Query(value = "SELECT cp.* FROM community_puzzle cp " +
             "JOIN user_community_puzzle ucp ON ucp.community_id = cp.id " +
-            "WHERE ucp.user_id = :userId AND ucp.is_liked = TRUE AND ucp.liked_at IS NOT NULL " +
+            "WHERE cp.status != 'DELETED' AND ucp.user_id = :userId AND ucp.is_liked = TRUE AND ucp.liked_at IS NOT NULL " +
             "AND (" +
             "   :cursorId IS NULL " +
             "   OR (ucp.liked_at, cp.id) < (SELECT ucp2.liked_at, cp2.id FROM user_community_puzzle ucp2 " +
@@ -27,7 +27,7 @@ public interface CommunityPuzzleRepository extends JpaRepository<CommunityPuzzle
     List<CommunityPuzzle> getUserLikedPuzzles(@Param("userId") Long userId, @Param("cursorId") Long cursorId, @Param("size") int size);
 
     @Query(value = "SELECT cp.* FROM community_puzzle cp " +
-            "WHERE cp.author_id = :userId " +
+            "WHERE cp.status != 'DELETED' AND cp.author_id = :userId " +
             "AND (" +
             "   :cursorId IS NULL " +
             "   OR (cp.created_at, cp.id) < (SELECT cp2.created_at, cp2.id FROM community_puzzle cp2 " +

--- a/src/main/java/com/renzzle/backend/domain/puzzle/community/dao/UserCommunityPuzzleRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/community/dao/UserCommunityPuzzleRepository.java
@@ -32,7 +32,7 @@ public interface UserCommunityPuzzleRepository extends JpaRepository<UserCommuni
             @Param("userId") Long userId,
             @Param("puzzleId") Long puzzleId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("UPDATE UserCommunityPuzzle ucp SET ucp.isSolved = TRUE, ucp.solvedAt = :solvedAt " +
             "WHERE ucp.user.id = :userId AND ucp.puzzle.id = :puzzleId")
     int solvePuzzle(@Param("userId") Long userId, @Param("puzzleId") Long puzzleId, @Param("solvedAt") Instant solvedAt);

--- a/src/main/java/com/renzzle/backend/domain/puzzle/community/domain/CommunityPuzzle.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/community/domain/CommunityPuzzle.java
@@ -110,4 +110,21 @@ public class CommunityPuzzle {
     public void increaseSolvedCount() {
         this.solvedCount++;
     }
+
+    public void increaseLikedCount() {
+        this.likeCount++;
+    }
+
+    public void increaseDislikedCount() {
+        this.dislikeCount++;
+    }
+
+    public void decreaseLikedCount() {
+        this.likeCount--;
+    }
+
+    public void decreaseDislikedCount() {
+        this.dislikeCount--;
+    }
+
 }

--- a/src/main/java/com/renzzle/backend/domain/puzzle/community/service/CommunityService.java
+++ b/src/main/java/com/renzzle/backend/domain/puzzle/community/service/CommunityService.java
@@ -128,7 +128,7 @@ public class CommunityService {
 
         persistedUser.purchase(HINT.getPrice());
 
-        solveCommunityPuzzle(puzzleId, user);
+        solveCommunityPuzzle(puzzleId, persistedUser);
 
         return GetCommunityPuzzleAnswerResponse.builder()
                 .answer(puzzle.getAnswer())
@@ -165,6 +165,11 @@ public class CommunityService {
 
         Optional<UserCommunityPuzzle> ucp = userCommunityPuzzleRepository.findByUserIdAndPuzzleId(user.getId(), puzzleId);
         if (ucp.isPresent()) {
+            if (ucp.get().isLiked()) puzzle.decreaseLikedCount();
+            else {
+                if (ucp.get().isDisliked()) puzzle.decreaseDislikedCount();
+                puzzle.increaseLikedCount();
+            }
             return ucp.get().toggleLike(clock.instant());
         }
 
@@ -176,6 +181,7 @@ public class CommunityService {
                         .likedAt(clock.instant())
                         .build()
         );
+        puzzle.increaseLikedCount();
 
         return true;
     }
@@ -187,6 +193,11 @@ public class CommunityService {
 
         Optional<UserCommunityPuzzle> ucp = userCommunityPuzzleRepository.findByUserIdAndPuzzleId(user.getId(), puzzleId);
         if (ucp.isPresent()) {
+            if (ucp.get().isDisliked()) puzzle.decreaseDislikedCount();
+            else {
+                if (ucp.get().isLiked()) puzzle.decreaseLikedCount();
+                puzzle.increaseDislikedCount();
+            }
             return ucp.get().toggleDislike();
         }
 
@@ -197,6 +208,7 @@ public class CommunityService {
                         .isDisliked(true)
                         .build()
         );
+        puzzle.increaseDislikedCount();
 
         return true;
     }

--- a/src/main/java/com/renzzle/backend/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/renzzle/backend/domain/user/dao/UserRepository.java
@@ -21,12 +21,12 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     Optional<UserEntity> findByEmail(String email);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("UPDATE UserEntity u SET u.status = (SELECT s FROM Status s WHERE s.name = 'DELETED'), " +
             "u.deletedAt = :deletedAt WHERE u.id = :userId")
     int softDelete(@Param("userId") Long userId, @Param("deletedAt") Instant deletedAt);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("UPDATE UserEntity u SET u.currency = u.currency + :amount WHERE u.id = :userId")
     void addUserCurrency(@Param("userId") Long userId, @Param("amount") int amount);
 
@@ -59,14 +59,14 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     @Query("SELECT CASE WHEN (u.lastAccessedAt < CURRENT_DATE) THEN true ELSE false END FROM UserEntity u WHERE u.id = :userId")
     Boolean isLastAccessBeforeToday(@Param("userId") Long userId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("UPDATE UserEntity u SET u.lastAccessedAt = :lastAccessedAt WHERE u.id = :userId")
     void updateLastAccessedAt(@Param("userId") Long userId, @Param("lastAccessedAt") Instant lastAccessedAt);
 
     @Query("SELECT u.title FROM UserEntity u WHERE u.id = :userId")
     Optional<Title> getUserTitle(@Param("userId") Long userId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("UPDATE UserEntity u SET u.title = :title WHERE u.id = :userId")
     void updateUserTitle(@Param("userId") Long userId, @Param("title") Title title);
 

--- a/src/test/java/com/renzzle/backend/domain/puzzle/community/dao/CommunityPuzzleRepositoryTest.java
+++ b/src/test/java/com/renzzle/backend/domain/puzzle/community/dao/CommunityPuzzleRepositoryTest.java
@@ -9,6 +9,7 @@ import com.renzzle.backend.global.common.domain.Status;
 import com.renzzle.backend.support.TestCommunityPuzzleBuilder;
 import com.renzzle.backend.support.TestUserCommunityPuzzleBuilder;
 import com.renzzle.backend.support.TestUserEntityBuilder;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -21,6 +22,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTestWithInitContainers
 public class CommunityPuzzleRepositoryTest {
+
+    @Autowired
+    private EntityManager entityManager;
 
     @Autowired
     private UserRepository userRepository;
@@ -276,6 +280,8 @@ public class CommunityPuzzleRepositoryTest {
 
         // When
         int updatedCount = communityPuzzleRepository.softDelete(puzzle.getId(), deletedTime);
+        entityManager.flush();
+        entityManager.clear();
 
         // Then
         CommunityPuzzle deletedPuzzle = communityPuzzleRepository.findByIdIncludingDeleted(puzzle.getId());

--- a/src/test/java/com/renzzle/backend/domain/puzzle/community/dao/UserCommunityPuzzleRepositoryTest.java
+++ b/src/test/java/com/renzzle/backend/domain/puzzle/community/dao/UserCommunityPuzzleRepositoryTest.java
@@ -9,6 +9,7 @@ import com.renzzle.backend.support.DataJpaTestWithInitContainers;
 import com.renzzle.backend.support.TestCommunityPuzzleBuilder;
 import com.renzzle.backend.support.TestUserCommunityPuzzleBuilder;
 import com.renzzle.backend.support.TestUserEntityBuilder;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -20,6 +21,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTestWithInitContainers
 public class UserCommunityPuzzleRepositoryTest {
+
+    @Autowired
+    private EntityManager entityManager;
 
     @Autowired
     private UserRepository userRepository;
@@ -92,6 +96,8 @@ public class UserCommunityPuzzleRepositoryTest {
 
         // When
         int updatedCount = userCommunityPuzzleRepository.solvePuzzle(user.getId(), puzzle.getId(), fixedTime);
+        entityManager.flush();
+        entityManager.clear();
 
         // Then
         UserCommunityPuzzle updated = userCommunityPuzzleRepository.findByUserIdAndPuzzleId(user.getId(), puzzle.getId()).orElseThrow();

--- a/src/test/java/com/renzzle/backend/domain/user/dao/UserRepositoryTest.java
+++ b/src/test/java/com/renzzle/backend/domain/user/dao/UserRepositoryTest.java
@@ -7,6 +7,7 @@ import com.renzzle.backend.global.common.domain.Status;
 import com.renzzle.backend.support.DataJpaTestWithInitContainers;
 import com.renzzle.backend.support.TestCommunityPuzzleBuilder;
 import com.renzzle.backend.support.TestUserEntityBuilder;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -20,10 +21,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class UserRepositoryTest {
 
     @Autowired
-    UserRepository userRepository;
+    private EntityManager entityManager;
 
     @Autowired
-    CommunityPuzzleRepository communityPuzzleRepository;
+    private UserRepository userRepository;
+
+    @Autowired
+    private CommunityPuzzleRepository communityPuzzleRepository;
 
     @Test
     void existsByEmail_WhenEmailExists_ThenReturnTrue() {
@@ -75,6 +79,8 @@ public class UserRepositoryTest {
         Instant deletedAt = Instant.parse("2025-04-15T12:00:00.000000Z");
 
         userRepository.softDelete(user.getId(), deletedAt);
+        entityManager.flush();
+        entityManager.clear();
         UserEntity deletedUser = userRepository.findByIdIncludingDeleted(user.getId());
 
         assertThat(deletedUser.getStatus().getName()).isEqualTo(Status.StatusName.DELETED.name());
@@ -86,6 +92,8 @@ public class UserRepositoryTest {
         var user = TestUserEntityBuilder.builder().withCurrency(100).save(userRepository);
 
         userRepository.addUserCurrency(user.getId(), 50);
+        entityManager.flush();
+        entityManager.clear();
         UserEntity updatedUser = userRepository.findById(user.getId()).orElseThrow();
 
         assertThat(updatedUser.getCurrency()).isEqualTo(150);
@@ -107,6 +115,8 @@ public class UserRepositoryTest {
         Instant now = Instant.parse("2025-04-15T12:00:00.000000Z");
 
         userRepository.updateLastAccessedAt(user.getId(), now);
+        entityManager.flush();
+        entityManager.clear();
         UserEntity updatedUser = userRepository.findById(user.getId()).orElseThrow();
 
         assertThat(updatedUser.getLastAccessedAt()).isEqualTo(now);
@@ -128,6 +138,8 @@ public class UserRepositoryTest {
         Title newTitle = Title.getTitle(Title.TitleType.MASTER);
 
         userRepository.updateUserTitle(user.getId(), newTitle);
+        entityManager.flush();
+        entityManager.clear();
         UserEntity updated = userRepository.findById(user.getId()).orElseThrow();
 
         assertThat(updated.getTitle()).isEqualTo(newTitle);


### PR DESCRIPTION
### ✏️ 작업 개요
테스트를 통해 찾은 버그들 수정

### 🔨 작업 상세 내용
1. SQLRestriction이 nativeQuery에는 적용이 안되어 삭제된 커뮤니티 퍼즐이 조회되던 문제 수정
2. 커뮤니티 문제 좋아요/싫어요 요청 시 커뮤니티 퍼즐 필드에 총 좋아요/싫어요 수 집계가 안되던 문제 수정
3. clearAutomatically 옵션으로 인한 영속성 컨텍스트를 clear하면서 생기는 버그들 수정 (그에 맞추어 테스트 코드도 수정)
