### PR TITLE
fix:cloudflare certificate apply

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -106,6 +106,16 @@ jobs:
           key: ${{ secrets.PRIVATE_KEY }}
           script: sudo rm -rf /home/ubuntu/caddy
 
+      - name: Create Cloudflare Origin cert files
+        run: |
+          mkdir -p caddy/origin
+          cat > caddy/origin/renzzle.com.pem <<'EOF'
+          ${{ secrets.CF_ORIGIN_CERT }}
+          EOF
+          cat > caddy/origin/renzzle.com.key <<'EOF'
+          ${{ secrets.CF_ORIGIN_KEY }}
+          EOF
+
       - name: Copy Caddy config to EC2
         uses: appleboy/scp-action@master
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ out/
 
 ### Google Play service account (never commit real keys) ###
 /secrets/
+
+### cloudflare key
+caddy/origin/

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -3,6 +3,8 @@
 }
 
 renzzle.com, www.renzzle.com {
+	tls /etc/caddy/origin/renzzle.com.pem /etc/caddy/origin/renzzle.com.key
+	
 	handle /app-ads.txt {
 		header Content-Type text/plain
 		respond "google.com, pub-8517144519151386, DIRECT, f08c47fec0942fa0" 200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       ACTUATOR_TOKEN: ${ACTUATOR_TOKEN}
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./caddy/origin:/etc/caddy/origin:ro
       - caddy-data:/data
       - caddy-config:/config
     networks:


### PR DESCRIPTION
### ✏️ 작업 개요
- Cloudflare Origin 인증서를 Caddy에 적용하여 TLS 구성을 전환.
- Cloudflare 프록시 + 오리진 방화벽 잠금으로 기존 caddy 의 자동 갱신 불가능해짐으로 인해 갱신이 필요 없는 Cloudflare Origin 인증서(15년)로 교체 


