### PR TITLE
Feat/password

### DIFF
--- a/src/main/java/com/renzzle/backend/domain/auth/api/AuthController.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/AuthController.java
@@ -57,6 +57,13 @@ public class AuthController {
         return ApiUtils.success(accountService.login(request));
     }
 
+    @Operation(summary = "Change password", description = "Verify the current password and change it to a new password")
+    @PatchMapping("/password")
+    public ApiResponse<Long> changePassword(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                            @Valid @RequestBody ChangePasswordRequest request) {
+        return ApiUtils.success(accountService.changePassword(userDetails.getUser(), request));
+    }
+
     @Operation(summary = "Logout to service", description = "Delete the refresh token to prevent reissuing the authentication tokens")
     @PostMapping("/logout")
     public ApiResponse<Long> logout(@AuthenticationPrincipal UserDetailsImpl userDetails) {

--- a/src/main/java/com/renzzle/backend/domain/auth/api/AuthController.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/AuthController.java
@@ -33,7 +33,7 @@ public class AuthController {
         return ApiUtils.success(emailService.sendCode(request));
     }
 
-    @Operation(summary = "Confirm code", description = "Authenticate code & Return token for sign up")
+    @Operation(summary = "Confirm code", description = "Authenticate code & Return token for sign up or password reset")
     @PostMapping("/confirmCode")
     public ApiResponse<ConfirmCodeResponse> confirmCode(@Valid @RequestBody ConfirmCodeRequest request) {
         return ApiUtils.success(emailService.confirmCode(request));
@@ -62,6 +62,18 @@ public class AuthController {
     public ApiResponse<Long> changePassword(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                             @Valid @RequestBody ChangePasswordRequest request) {
         return ApiUtils.success(accountService.changePassword(userDetails.getUser(), request));
+    }
+
+    @Operation(summary = "Send password reset code", description = "Send a confirmation code to a registered email")
+    @PostMapping("/password/reset/email")
+    public ApiResponse<AuthEmailResponse> sendPasswordResetCode(@Valid @RequestBody AuthEmailRequest request) {
+        return ApiUtils.success(emailService.sendPasswordResetCode(request));
+    }
+
+    @Operation(summary = "Reset password", description = "Reset password with a verified email token")
+    @PatchMapping("/password/reset")
+    public ApiResponse<Long> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
+        return ApiUtils.success(accountService.resetPassword(request));
     }
 
     @Operation(summary = "Logout to service", description = "Delete the refresh token to prevent reissuing the authentication tokens")

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/ChangePasswordRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/ChangePasswordRequest.java
@@ -1,0 +1,13 @@
+package com.renzzle.backend.domain.auth.api.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+
+public record ChangePasswordRequest(
+        @NotEmpty(message = "현재 비밀번호 정보가 없습니다")
+        String currentPassword,
+
+        @NotEmpty(message = "새 비밀번호 정보가 없습니다")
+        @Pattern(regexp = "^(?=.*[A-Za-z])[A-Za-z\\d]{8,}$", message = "새 비밀번호의 형식이 올바르지 않습니다")
+        String newPassword
+) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/api/request/ResetPasswordRequest.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/api/request/ResetPasswordRequest.java
@@ -1,0 +1,18 @@
+package com.renzzle.backend.domain.auth.api.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+
+public record ResetPasswordRequest(
+        @NotEmpty(message = "이메일 정보가 없습니다")
+        @Email(message = "이메일 형식이 아닙니다")
+        String email,
+
+        @NotEmpty(message = "토큰 정보가 없습니다")
+        String authVerityToken,
+
+        @NotEmpty(message = "새 비밀번호 정보가 없습니다")
+        @Pattern(regexp = "^(?=.*[A-Za-z])[A-Za-z\\d]{8,}$", message = "새 비밀번호의 형식이 올바르지 않습니다")
+        String newPassword
+) { }

--- a/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
@@ -1,5 +1,6 @@
 package com.renzzle.backend.domain.auth.service;
 
+import com.renzzle.backend.domain.auth.api.request.ChangePasswordRequest;
 import com.renzzle.backend.domain.auth.api.request.LoginRequest;
 import com.renzzle.backend.domain.auth.api.request.SignupRequest;
 import com.renzzle.backend.domain.auth.api.response.LoginResponse;
@@ -89,6 +90,19 @@ public class AccountService {
         long userId = user.get().getId();
 
         return authService.createAuthTokens(userId);
+    }
+
+    @Transactional
+    public Long changePassword(UserEntity user, ChangePasswordRequest request) {
+        UserEntity persistedUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.CANNOT_FIND_USER));
+
+        if (!passwordEncoder.matches(request.currentPassword(), persistedUser.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        persistedUser.changePassword(passwordEncoder.encode(request.newPassword()));
+        return persistedUser.getId();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/AccountService.java
@@ -2,6 +2,7 @@ package com.renzzle.backend.domain.auth.service;
 
 import com.renzzle.backend.domain.auth.api.request.ChangePasswordRequest;
 import com.renzzle.backend.domain.auth.api.request.LoginRequest;
+import com.renzzle.backend.domain.auth.api.request.ResetPasswordRequest;
 import com.renzzle.backend.domain.auth.api.request.SignupRequest;
 import com.renzzle.backend.domain.auth.api.response.LoginResponse;
 import com.renzzle.backend.domain.auth.dao.AdminRepository;
@@ -103,6 +104,20 @@ public class AccountService {
 
         persistedUser.changePassword(passwordEncoder.encode(request.newPassword()));
         return persistedUser.getId();
+    }
+
+    @Transactional
+    public Long resetPassword(ResetPasswordRequest request) {
+        if (!authService.verifyAuthVerityToken(request.authVerityToken(), request.email())) {
+            throw new CustomException(ErrorCode.INVALID_AUTH_VERITY_TOKEN);
+        }
+
+        UserEntity user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_EMAIL));
+
+        user.changePassword(passwordEncoder.encode(request.newPassword()));
+        authService.deleteRefreshToken(user);
+        return user.getId();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/renzzle/backend/domain/auth/service/EmailSender.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/EmailSender.java
@@ -25,16 +25,25 @@ public class EmailSender {
 
     @Async
     public void sendAuthEmail(String address, String code) {
+        sendEmail(address, code, "[Renzzle] Email Verification", "email/verification");
+    }
+
+    @Async
+    public void sendPasswordResetEmail(String address, String code) {
+        sendEmail(address, code, "[Renzzle] Password Reset", "email/password-reset");
+    }
+
+    private void sendEmail(String address, String code, String subject, String template) {
         MimeMessage message = javaMailSender.createMimeMessage();
 
         try {
             message.setFrom(senderEmail);
             message.setRecipients(Message.RecipientType.TO, address);
-            message.setSubject("[Renzzle] Email Verification");
+            message.setSubject(subject);
 
             Context context = new Context();
             context.setVariable("verificationCode", code);
-            String htmlContent = templateEngine.process("email/verification", context);
+            String htmlContent = templateEngine.process(template, context);
 
             message.setText(htmlContent, "UTF-8", "html");
         } catch (MessagingException e) {

--- a/src/main/java/com/renzzle/backend/domain/auth/service/EmailService.java
+++ b/src/main/java/com/renzzle/backend/domain/auth/service/EmailService.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 
 @Service
 @RequiredArgsConstructor
@@ -49,15 +50,28 @@ public class EmailService {
             throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
         }
 
-        int count = getRequestCount(request.email());
+        return sendCodeTo(request.email(), emailSender::sendAuthEmail);
+    }
+
+    @Transactional
+    public AuthEmailResponse sendPasswordResetCode(AuthEmailRequest request) {
+        if(!accountService.isDuplicatedEmail(request.email())) {
+            throw new CustomException(ErrorCode.INVALID_EMAIL);
+        }
+
+        return sendCodeTo(request.email(), emailSender::sendPasswordResetEmail);
+    }
+
+    private AuthEmailResponse sendCodeTo(String email, BiConsumer<String, String> emailConsumer) {
+        int count = getRequestCount(email);
         if(count >= EMAIL_VERIFICATION_LIMIT) {
             throw new CustomException(ErrorCode.EXCEED_EMAIL_AUTH_REQUEST);
         }
 
         String code = generateRandomCode();
-        emailSender.sendAuthEmail(request.email(), code);
+        emailConsumer.accept(email, code);
 
-        saveConfirmCode(request.email(), code, count);
+        saveConfirmCode(email, code, count);
 
         return AuthEmailResponse
                 .builder()

--- a/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
+++ b/src/main/java/com/renzzle/backend/domain/user/domain/UserEntity.java
@@ -141,4 +141,8 @@ public class UserEntity {
         purchase(ItemPrice.CHANGE_NICKNAME.getPrice());
         this.nickname = nickname;
     }
+
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
 }

--- a/src/main/java/com/renzzle/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/renzzle/backend/global/config/SecurityConfig.java
@@ -44,6 +44,8 @@ public class SecurityConfig {
                 AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/favicon.ico"),
                 AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/api/auth/email"),
                 AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/api/auth/confirmCode"),
+                AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/api/auth/password/reset/email"),
+                AntPathRequestMatcher.antMatcher(HttpMethod.PATCH, "/api/auth/password/reset"),
                 AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/api/auth/duplicate/**"),
                 AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/api/auth/login"),
                 AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/api/auth/signup"),

--- a/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/renzzle/backend/global/exception/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
     // Auth
     EXCEED_EMAIL_AUTH_REQUEST(HttpStatus.TOO_MANY_REQUESTS, "A429", "이메일 인증 횟수를 초과했습니다."),
     INVALID_EMAIL_AUTH_CODE(HttpStatus.UNAUTHORIZED, "A4010", "유효하지 않은 인증코드입니다."),
-    INVALID_AUTH_VERITY_TOKEN(HttpStatus.UNAUTHORIZED, "A4011", "유효하지 않은 회원가입 인증 토큰입니다."),
+    INVALID_AUTH_VERITY_TOKEN(HttpStatus.UNAUTHORIZED, "A4011", "유효하지 않은 이메일 인증 토큰입니다."),
     INVALID_EMAIL(HttpStatus.UNAUTHORIZED, "A4012", "유효하지 않은 이메일입니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "A4013", "유효하지 않은 비밀번호입니다."),
     NOT_BEARER_GRANT_TYPE(HttpStatus.UNAUTHORIZED, "A4014", "인증 타입이 Bearer 타입이 아닙니다."),

--- a/src/main/resources/templates/email/password-reset.html
+++ b/src/main/resources/templates/email/password-reset.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Renzzle Password Reset</title>
+    </head>
+    <body style="font-family: Arial, sans-serif; background-color: #f4f4f4; margin: 0; padding: 0;">
+        <div style="max-width: 600px; margin: 20px auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1);">
+            <div style="background-color: #176B5F; color: #ffffff; padding: 20px; text-align: center; border-top-left-radius: 8px; border-top-right-radius: 8px;">
+                <h2 style="margin: 0; font-size: 24px; color: #ffffff;">Renzzle</h2>
+            </div>
+            <div style="padding: 30px; text-align: center;">
+                <h1 style="color: #333333; margin-bottom: 20px; font-size: 28px;">Password Reset</h1>
+                <p style="color: #666666; line-height: 1.6; margin-bottom: 30px; font-size: 16px;">
+                    Enter the verification code below to reset your password.
+                </p>
+                <div style="font-size: 30px; font-weight: bold; color: #176B5F; background-color: #E8F3F1; padding: 15px; border-radius: 4px; letter-spacing: 4px; display: inline-block;">
+                    <span th:text="${verificationCode}">123456</span>
+                </div>
+                <p style="color: #666666; margin-top: 30px; font-size: 14px;">This code is valid for 5 minutes.</p>
+            </div>
+            <div style="background-color: #f8f8f8; color: #555555; text-align: center; padding: 15px; font-size: 12px; border-bottom-left-radius: 8px; border-bottom-right-radius: 8px;">
+                &copy; 2024 Renzzle. All rights reserved.
+            </div>
+        </div>
+    </body>
+</html>

--- a/src/test/java/com/renzzle/backend/domain/auth/service/AccountServiceTest.java
+++ b/src/test/java/com/renzzle/backend/domain/auth/service/AccountServiceTest.java
@@ -1,5 +1,6 @@
 package com.renzzle.backend.domain.auth.service;
 
+import com.renzzle.backend.domain.auth.api.request.ChangePasswordRequest;
 import com.renzzle.backend.domain.auth.api.request.LoginRequest;
 import com.renzzle.backend.domain.auth.api.request.SignupRequest;
 import com.renzzle.backend.domain.auth.api.response.LoginResponse;
@@ -130,6 +131,43 @@ class AccountServiceTest {
         CustomException ex = assertThrows(CustomException.class, () -> accountService.login(validLoginRequest));
 
         assertEquals(ErrorCode.INVALID_PASSWORD, ex.getErrorCode());
+    }
+
+    @Test
+    void changePassword_ShouldChangePassword_WhenCurrentPasswordMatches() {
+        UserEntity user = UserEntity.builder()
+                .id(1L)
+                .email(email)
+                .password(new BCryptPasswordEncoder().encode(password))
+                .nickname(nickname)
+                .deviceId(deviceId)
+                .build();
+        ChangePasswordRequest request = new ChangePasswordRequest(password, "newPassword123");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        Long changedUserId = accountService.changePassword(user, request);
+
+        assertEquals(1L, changedUserId);
+        assertTrue(new BCryptPasswordEncoder().matches(request.newPassword(), user.getPassword()));
+    }
+
+    @Test
+    void changePassword_ShouldThrowException_WhenCurrentPasswordMismatch() {
+        UserEntity user = UserEntity.builder()
+                .id(1L)
+                .email(email)
+                .password(new BCryptPasswordEncoder().encode(password))
+                .nickname(nickname)
+                .deviceId(deviceId)
+                .build();
+        ChangePasswordRequest request = new ChangePasswordRequest("wrongPassword", "newPassword123");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        CustomException ex = assertThrows(CustomException.class,
+                () -> accountService.changePassword(user, request));
+
+        assertEquals(ErrorCode.INVALID_PASSWORD, ex.getErrorCode());
+        assertTrue(new BCryptPasswordEncoder().matches(password, user.getPassword()));
     }
 
 }

--- a/src/test/java/com/renzzle/backend/domain/auth/service/AccountServiceTest.java
+++ b/src/test/java/com/renzzle/backend/domain/auth/service/AccountServiceTest.java
@@ -2,6 +2,7 @@ package com.renzzle.backend.domain.auth.service;
 
 import com.renzzle.backend.domain.auth.api.request.ChangePasswordRequest;
 import com.renzzle.backend.domain.auth.api.request.LoginRequest;
+import com.renzzle.backend.domain.auth.api.request.ResetPasswordRequest;
 import com.renzzle.backend.domain.auth.api.request.SignupRequest;
 import com.renzzle.backend.domain.auth.api.response.LoginResponse;
 import com.renzzle.backend.domain.user.dao.UserRepository;
@@ -168,6 +169,38 @@ class AccountServiceTest {
 
         assertEquals(ErrorCode.INVALID_PASSWORD, ex.getErrorCode());
         assertTrue(new BCryptPasswordEncoder().matches(password, user.getPassword()));
+    }
+
+    @Test
+    void resetPassword_ShouldChangePasswordAndDeleteRefreshToken_WhenTokenIsValid() {
+        UserEntity user = UserEntity.builder()
+                .id(1L)
+                .email(email)
+                .password(new BCryptPasswordEncoder().encode(password))
+                .nickname(nickname)
+                .deviceId(deviceId)
+                .build();
+        ResetPasswordRequest request = new ResetPasswordRequest(email, authVerityToken, "newPassword123");
+        when(authService.verifyAuthVerityToken(authVerityToken, email)).thenReturn(true);
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        Long resetUserId = accountService.resetPassword(request);
+
+        assertEquals(1L, resetUserId);
+        assertTrue(new BCryptPasswordEncoder().matches(request.newPassword(), user.getPassword()));
+        verify(authService).deleteRefreshToken(user);
+    }
+
+    @Test
+    void resetPassword_ShouldThrowException_WhenTokenDoesNotMatchEmail() {
+        ResetPasswordRequest request = new ResetPasswordRequest(email, "invalid-token", "newPassword123");
+        when(authService.verifyAuthVerityToken(request.authVerityToken(), email)).thenReturn(false);
+
+        CustomException ex = assertThrows(CustomException.class,
+                () -> accountService.resetPassword(request));
+
+        assertEquals(ErrorCode.INVALID_AUTH_VERITY_TOKEN, ex.getErrorCode());
+        verify(userRepository, never()).findByEmail(anyString());
     }
 
 }

--- a/src/test/java/com/renzzle/backend/domain/auth/service/EmailServiceTest.java
+++ b/src/test/java/com/renzzle/backend/domain/auth/service/EmailServiceTest.java
@@ -76,6 +76,30 @@ class EmailServiceTest {
     }
 
     @Test
+    void sendPasswordResetCode_ShouldSendEmail_WhenEmailExists() {
+        AuthEmailRequest request = new AuthEmailRequest("registered@example.com");
+        when(accountService.isDuplicatedEmail(request.email())).thenReturn(true);
+        when(emailRepository.findById(request.email())).thenReturn(Optional.empty());
+
+        AuthEmailResponse response = emailService.sendPasswordResetCode(request);
+
+        assertThat(response.requestCount()).isEqualTo(1);
+        verify(emailSender).sendPasswordResetEmail(eq(request.email()), any(String.class));
+    }
+
+    @Test
+    void sendPasswordResetCode_ShouldThrowException_WhenEmailDoesNotExist() {
+        AuthEmailRequest request = new AuthEmailRequest("unknown@example.com");
+        when(accountService.isDuplicatedEmail(request.email())).thenReturn(false);
+
+        CustomException exception = assertThrows(CustomException.class,
+                () -> emailService.sendPasswordResetCode(request));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_EMAIL);
+        verifyNoInteractions(emailSender);
+    }
+
+    @Test
     void sendCode_ExceedRequestCount_ShouldThrowException() {
         // given
         AuthEmailRequest request = new AuthEmailRequest("test@example.com");


### PR DESCRIPTION
### ✏️ 작업 개요
이메일 인증을 통한 비밀번호 재설정 기능을 추가

### 🔨 작업 상세 내용
1. 비밀번호 초기화 인증번호 발송
- `POST /api/auth/password/reset/email`
- 가입된 이메일인지 확인
- 미가입 이메일이면 `INVALID_EMAIL` 반환
- 가입된 이메일에 6자리 인증번호 발송
- 비밀번호 초기화 전용 이메일 제목 및 템플릿 추가
- 기존 이메일 발송 횟수 제한과 인증번호 유효시간 재사용

2. 비밀번호 재설정
- `PATCH /api/auth/password/reset`
- 기존 `/api/auth/confirmCode`에서 발급받은 이메일 인증 토큰 사용
- 토큰과 이메일 일치 여부 검증
- 새 비밀번호를 BCrypt로 암호화하여 저장
- 비밀번호 변경 후 기존 리프레시 토큰 삭제

### 📎 비밀번호 재설정 흐름

1. 초기화 인증번호 발송
3. `/api/auth/confirmCode`를 통한 인증번호 확인 및 토큰 발급
4. 발급받은 토큰으로 새 비밀번호 설정

### 💡 생각해볼 문제
- 이메일 및 IP 기반 Rate Limit 강화 필요
- 비밀번호 초기화 토큰 용도 분리 및 일회성 처리 필요